### PR TITLE
Add support for Nuvoton NCT6694 USB device sharing peripherals

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -467,6 +467,22 @@ config GPIO_MXS
 	select GPIO_GENERIC
 	select GENERIC_IRQ_CHIP
 
+config GPIO_MAX732X_IRQ
+        bool "Interrupt controller support for MAX732x"
+        depends on GPIO_MAX732X=y
+        select GPIOLIB_IRQCHIP
+        help
+          Say yes here to enable the max732x to be used as an interrupt
+          controller. It requires the driver to be built in the kernel.
+
+config GPIO_NCT6694
+        tristate "Nuvoton NCT6694 GPIO controller support"
+        depends on MFD_NCT6694
+        select GENERIC_IRQ_CHIP
+        select GPIOLIB_IRQCHIP
+        help
+          Say Y here to support Nuvoton NCT6694 GPIO controller.
+
 config GPIO_OCTEON
 	tristate "Cavium OCTEON GPIO"
 	depends on CAVIUM_OCTEON_SOC

--- a/drivers/gpio/Makefile
+++ b/drivers/gpio/Makefile
@@ -110,6 +110,7 @@ obj-$(CONFIG_GPIO_MT7621)		+= gpio-mt7621.o
 obj-$(CONFIG_GPIO_MVEBU)		+= gpio-mvebu.o
 obj-$(CONFIG_GPIO_MXC)			+= gpio-mxc.o
 obj-$(CONFIG_GPIO_MXS)			+= gpio-mxs.o
+obj-$(CONFIG_GPIO_NCT6694)		+= gpio-nct6694.o
 obj-$(CONFIG_GPIO_OCTEON)		+= gpio-octeon.o
 obj-$(CONFIG_GPIO_OMAP)			+= gpio-omap.o
 obj-$(CONFIG_GPIO_PALMAS)		+= gpio-palmas.o

--- a/drivers/gpio/gpio-nct6694.c
+++ b/drivers/gpio/gpio-nct6694.c
@@ -1,0 +1,517 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 GPIO controller driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/gpio.h>
+#include <linux/module.h>
+#include <linux/interrupt.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define DRVNAME "nct6694-gpio"
+
+/* Host interface */
+#define REQUEST_GPIO_MOD		0xFF
+#define REQUEST_GPIO_LEN		0x01
+
+/* Report Channel */
+#define GPIO_VER_REG			0x90
+#define GPIO_VALID_REG			0x110
+#define GPI_DATA_REG			0x120
+#define GPO_DIR_REG			0x170
+#define GPO_TYPE_REG			0x180
+#define GPO_DATA_REG			0x190
+
+#define GPI_STS_REG			0x130
+#define GPI_CLR_REG			0x140
+#define GPI_FALLING_REG			0x150
+#define GPI_RISING_REG			0x160
+
+#define GPIO_BANK_NR			0xF	/* 16 banks gpio */
+
+struct nct6694_gpio_data {
+	struct nct6694 *nct6694;
+	struct nct6694_gpio_bank *bank;
+	struct work_struct irq_work;
+
+	struct mutex irq_lock;
+	int nr_bank;
+	u8 irq_trig_type[32];	/* irq_trig_type | FALLING | RISING |*/
+};
+
+struct nct6694_gpio_bank {
+	struct gpio_chip gpio;
+	struct nct6694_gpio_data *data;
+
+	/* Current gpio bank */
+	unsigned char group;
+};
+
+static int nct6694_get_direction(struct gpio_chip *gpio, unsigned int offset)
+{
+	struct nct6694_gpio_bank *bank = gpiochip_get_data(gpio);
+	struct nct6694_gpio_data *data = bank->data;
+	unsigned char ret, buf;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPO_DIR_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+		return -EINVAL;
+	}
+
+	return !(BIT(offset) & buf);
+}
+
+static int nct6694_direction_input(struct gpio_chip *gpio, unsigned int offset)
+{
+	struct nct6694_gpio_bank *bank = gpiochip_get_data(gpio);
+	struct nct6694_gpio_data *data = bank->data;
+	unsigned char ret, buf;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPO_DIR_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+		return -EINVAL;
+	}
+	buf &= ~(1 << offset);
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_GPIO_MOD,
+				   GPO_DIR_REG + bank->group, REQUEST_GPIO_LEN,
+				   &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to set data to usb device!\n", __func__);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int nct6694_direction_output(struct gpio_chip *gpio,
+				    unsigned int offset, int val)
+{
+	struct nct6694_gpio_bank *bank = gpiochip_get_data(gpio);
+	struct nct6694_gpio_data *data = bank->data;
+	unsigned char ret, buf;
+
+	/* Set direction to output */
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPO_DIR_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+		return -EINVAL;
+	}
+	buf |= (1 << offset);
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_GPIO_MOD,
+				   GPO_DIR_REG + bank->group, REQUEST_GPIO_LEN,
+				   &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to set data to usb device!\n", __func__);
+		return -EINVAL;
+	}
+
+	/* Then set output level */
+	ret = nct6694_getusb(data->nct6694, 0xFF, GPO_DATA_REG + bank->group,
+			     REQUEST_GPIO_LEN, 0, 1, &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+		return -EINVAL;
+	}
+	if (val)
+		buf |= (1 << offset);
+	else
+		buf &= ~(1 << offset);
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_GPIO_MOD,
+				   GPO_DATA_REG + bank->group, REQUEST_GPIO_LEN,
+				   &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to set data to usb device!\n", __func__);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int nct6694_get_value(struct gpio_chip *gpio, unsigned int offset)
+{
+	struct nct6694_gpio_bank *bank = gpiochip_get_data(gpio);
+	struct nct6694_gpio_data *data = bank->data;
+	unsigned char ret, buf;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPO_DIR_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+		return -EINVAL;
+	}
+
+	if (BIT(offset) & buf) {
+		ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+				     GPO_DATA_REG + bank->group, REQUEST_GPIO_LEN,
+				     0, 1, &buf);
+		if (ret < 0) {
+			pr_err("%s: Failed to get data from usb device!\n", __func__);
+			return -EINVAL;
+		}
+		return !!(BIT(offset) & buf);
+	}
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPI_DATA_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+		return -EINVAL;
+	}
+	return !!(BIT(offset) & buf);
+}
+
+static void nct6694_set_value(struct gpio_chip *gpio, unsigned int offset, int val)
+{
+	struct nct6694_gpio_bank *bank = gpiochip_get_data(gpio);
+	struct nct6694_gpio_data *data = bank->data;
+	unsigned char ret, buf;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPO_DATA_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0)
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+
+	if (val)
+		buf |= (1 << offset);
+	else
+		buf &= ~(1 << offset);
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_GPIO_MOD,
+				   GPO_DATA_REG + bank->group, REQUEST_GPIO_LEN,
+				   &buf);
+	if (ret < 0)
+		pr_err("%s: Failed to set data to usb device!\n", __func__);
+}
+
+static int nct6694_set_config(struct gpio_chip *gpio, unsigned int offset,
+			      unsigned long config)
+{
+	struct nct6694_gpio_bank *bank = gpiochip_get_data(gpio);
+	struct nct6694_gpio_data *data = bank->data;
+	unsigned char ret, buf;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPO_TYPE_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0)
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+
+	switch (pinconf_to_config_param(config)) {
+	case PIN_CONFIG_DRIVE_OPEN_DRAIN:
+		buf |= (1 << offset);
+		break;
+	case PIN_CONFIG_DRIVE_PUSH_PULL:
+		buf &= ~(1 << offset);
+		break;
+	default:
+		return -ENOTSUPP;
+	}
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_GPIO_MOD,
+				   GPO_TYPE_REG + bank->group, REQUEST_GPIO_LEN,
+				   &buf);
+	if (ret < 0)
+		pr_err("%s: Failed to set data to usb device!\n", __func__);
+
+	return 0;
+}
+
+static int nct6694_init_valid_mask(struct gpio_chip *gpio,
+				   unsigned long *valid_mask,
+				   unsigned int ngpios)
+{
+	struct nct6694_gpio_bank *bank = gpiochip_get_data(gpio);
+	struct nct6694_gpio_data *data = bank->data;
+	unsigned char ret, buf;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPIO_VALID_REG + bank->group, REQUEST_GPIO_LEN,
+			     0, 1, &buf);
+	if (ret < 0)
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+
+	*valid_mask = buf;
+
+	return 0;
+}
+
+#define NCT6694_GPIO_BANK(_group, _ngpio, _label)	\
+{	\
+	.gpio = {	\
+		.label            = _label,	\
+		.owner            = THIS_MODULE,	\
+		.direction_input  = nct6694_direction_input,	\
+		.get              = nct6694_get_value,	\
+		.direction_output = nct6694_direction_output,	\
+		.set              = nct6694_set_value,	\
+		.get_direction	  = nct6694_get_direction,	\
+		.set_config	  = nct6694_set_config,	\
+		.init_valid_mask  = nct6694_init_valid_mask,	\
+		.base             = -1,	\
+		.ngpio            = _ngpio,	\
+		.can_sleep        = false,	\
+	},	\
+	.group = _group,	\
+}
+
+static struct nct6694_gpio_bank nct6694_gpio_bank[] = {
+	NCT6694_GPIO_BANK(0, 8, "GPIO0"),
+	NCT6694_GPIO_BANK(1, 8, "GPIO1"),
+	NCT6694_GPIO_BANK(2, 8, "GPIO2"),
+	NCT6694_GPIO_BANK(3, 8, "GPIO3"),
+	NCT6694_GPIO_BANK(4, 8, "GPIO4"),
+	NCT6694_GPIO_BANK(5, 8, "GPIO5"),
+	NCT6694_GPIO_BANK(6, 8, "GPIO6"),
+	NCT6694_GPIO_BANK(7, 8, "GPIO7"),
+	NCT6694_GPIO_BANK(8, 8, "GPIO8"),
+	NCT6694_GPIO_BANK(9, 8, "GPIO9"),
+	NCT6694_GPIO_BANK(10, 8, "GPIOA"),
+	NCT6694_GPIO_BANK(11, 8, "GPIOB"),
+	NCT6694_GPIO_BANK(12, 8, "GPIOC"),
+	NCT6694_GPIO_BANK(13, 8, "GPIOD"),
+	NCT6694_GPIO_BANK(14, 8, "GPIOE"),
+	NCT6694_GPIO_BANK(15, 8, "GPIOF"),
+};
+
+static void nct6694_irq(struct work_struct *irq_work)
+{
+	struct nct6694_gpio_bank *bank = nct6694_gpio_bank;
+	struct nct6694_gpio_data *data = bank->data;
+	int ret, i;
+	u8 status[GPIO_BANK_NR];
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD,
+			     GPI_STS_REG, 16, 0, 16, status);
+	if (ret < 0)
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+
+	for (i = 0; i < GPIO_BANK_NR; i++) {
+		u8 stat = status[i];
+
+		if (!stat)
+			continue;
+
+		while (stat) {
+			int bit = __ffs(stat);
+			u8 val = BIT(bit);
+
+			handle_nested_irq(irq_find_mapping(bank[i].gpio.irq.domain, bit));
+			stat &= ~(1 << bit);
+			ret = nct6694_setusb_wdata(data->nct6694, REQUEST_GPIO_MOD,
+						   GPI_CLR_REG + i, REQUEST_GPIO_LEN,
+						   &val);
+			if (ret < 0)
+				pr_err("%s: Failed to set data to usb device!\n", __func__);
+		}
+	}
+}
+
+void nct6694_start_irq(struct nct6694 *nct6694)
+{
+	struct nct6694_gpio_bank *bank = nct6694_gpio_bank;
+	struct nct6694_gpio_data *data = bank->data;
+
+	queue_work(nct6694->async_workqueue, &data->irq_work);
+}
+
+static int nct6694_irq_trig(struct nct6694_gpio_data *data)
+{
+	int ret;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_GPIO_MOD, GPI_FALLING_REG,
+			     32, 0, 32, data->irq_trig_type);
+
+	return ret;
+}
+
+
+static void nct6694_irq_mask(struct irq_data *d)
+{
+	struct nct6694_gpio_bank *bank = irq_data_get_irq_chip_data(d);
+	irq_hw_number_t hwirq = irqd_to_hwirq(d);
+
+	gpiochip_disable_irq(&bank->gpio, hwirq);
+}
+
+static void nct6694_irq_unmask(struct irq_data *d)
+{
+	struct nct6694_gpio_bank *bank = irq_data_get_irq_chip_data(d);
+	irq_hw_number_t hwirq = irqd_to_hwirq(d);
+
+	gpiochip_enable_irq(&bank->gpio, hwirq);
+}
+
+static int nct6694_irq_set_type(struct irq_data *d, unsigned int type)
+{
+	struct nct6694_gpio_bank *bank = irq_data_get_irq_chip_data(d);
+	struct nct6694_gpio_data *data = bank->data;
+	irq_hw_number_t hwirq = irqd_to_hwirq(d);
+
+	switch (type) {
+	case IRQ_TYPE_EDGE_RISING:
+		data->irq_trig_type[bank->group + 0x10] |= BIT(hwirq);
+		break;
+
+	case IRQ_TYPE_EDGE_FALLING:
+		data->irq_trig_type[bank->group] |= BIT(hwirq);
+		break;
+
+	case IRQ_TYPE_EDGE_BOTH:
+		data->irq_trig_type[bank->group] |= BIT(hwirq);
+		data->irq_trig_type[bank->group + 0x10] |= BIT(hwirq);
+		break;
+
+	default:
+		return -ENOTSUPP;
+	}
+
+	nct6694_setusb_async(data->nct6694, REQUEST_GPIO_MOD, GPI_FALLING_REG,
+			     32, data->irq_trig_type);
+
+	return 0;
+}
+
+static void nct6694_irq_bus_lock(struct irq_data *d)
+{
+	struct nct6694_gpio_bank *bank = irq_data_get_irq_chip_data(d);
+	struct nct6694_gpio_data *data = bank->data;
+
+	mutex_lock(&data->irq_lock);
+}
+
+static void nct6694_irq_bus_sync_unlock(struct irq_data *d)
+{
+	struct nct6694_gpio_bank *bank = irq_data_get_irq_chip_data(d);
+	struct nct6694_gpio_data *data = bank->data;
+
+	mutex_unlock(&data->irq_lock);
+}
+
+static const struct irq_chip nct6694_irq_chip = {
+	.name			= "nct6694",
+	.irq_mask		= nct6694_irq_mask,
+	.irq_unmask		= nct6694_irq_unmask,
+	.irq_set_type		= nct6694_irq_set_type,
+	.irq_bus_lock		= nct6694_irq_bus_lock,
+	.irq_bus_sync_unlock	= nct6694_irq_bus_sync_unlock,
+	.flags			= IRQCHIP_IMMUTABLE,
+	GPIOCHIP_IRQ_RESOURCE_HELPERS,
+};
+
+static int nct6694_gpio_probe(struct platform_device *pdev)
+{
+	int ret, i;
+	struct nct6694_gpio_data *data;
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+
+	nct6694->gpio_handler = nct6694_start_irq;
+
+	data = kzalloc(sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->nct6694 = nct6694;
+	data->bank = nct6694_gpio_bank;
+	data->nr_bank = ARRAY_SIZE(nct6694_gpio_bank);
+	INIT_WORK(&data->irq_work, nct6694_irq);
+
+	mutex_init(&data->irq_lock);
+
+	platform_set_drvdata(pdev, data);
+
+	ret = nct6694_irq_trig(data);
+	if (ret) {
+		pr_err("Failed to get interrupt trigger type\n");
+		kfree(data);
+		return ret;
+	}
+
+	/* Register each gpio bank to GPIO framework */
+	for (i = 0; i < data->nr_bank; i++) {
+		struct nct6694_gpio_bank *bank = &data->bank[i];
+		struct gpio_irq_chip *girq;
+
+		bank->data  = data;
+
+		girq = &data->bank[i].gpio.irq;
+		gpio_irq_chip_set_chip(girq, &nct6694_irq_chip);
+		girq->parent_handler = NULL;
+		girq->num_parents = 0;
+		girq->parents = NULL;
+		girq->default_type = IRQ_TYPE_NONE;
+		girq->handler = handle_level_irq;
+		girq->threaded = true;
+
+		ret = gpiochip_add_data(&data->bank[i].gpio, &data->bank[i]);
+		if (ret) {
+			dev_err(&pdev->dev, "devm_gpiochip_add_data failed: %d", ret);
+			return ret;
+		}
+	}
+
+	dev_info(&pdev->dev, "Probe device :%s", pdev->name);
+
+	return 0;
+}
+
+static int nct6694_gpio_remove(struct platform_device *pdev)
+{
+	struct nct6694_gpio_data *data = platform_get_drvdata(pdev);
+	int ret, i;
+
+	ret = cancel_work(&data->irq_work);
+
+	for (i = 0; i < data->nr_bank; i++)
+		gpiochip_remove(&data->bank[i].gpio);
+
+	kfree(data);
+
+	return 0;
+}
+
+static struct platform_driver nct6694_gpio_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_gpio_probe,
+	.remove		= nct6694_gpio_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_gpio_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_gpio_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_gpio_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-GPIO controller driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");
+

--- a/drivers/hwmon/Kconfig
+++ b/drivers/hwmon/Kconfig
@@ -1494,6 +1494,12 @@ config SENSORS_NCT6683
 	  This driver can also be built as a module. If so, the module
 	  will be called nct6683.
 
+config SENSORS_NCT6694
+        tristate "Nuvoton NCT6694 Hardware Monitor support"
+        depends on MFD_NCT6694
+        help
+          Say Y here to support Nuvoton NCT6694 Hardware Monitor.
+
 config SENSORS_NCT6775_CORE
 	tristate
 	select REGMAP

--- a/drivers/hwmon/Makefile
+++ b/drivers/hwmon/Makefile
@@ -156,6 +156,7 @@ obj-$(CONFIG_SENSORS_MLXREG_FAN) += mlxreg-fan.o
 obj-$(CONFIG_SENSORS_MENF21BMC_HWMON) += menf21bmc_hwmon.o
 obj-$(CONFIG_SENSORS_MR75203)	+= mr75203.o
 obj-$(CONFIG_SENSORS_NCT6683)	+= nct6683.o
+obj-$(CONFIG_SENSORS_NCT6694)	+= nct6694-hwmon.o
 obj-$(CONFIG_SENSORS_NCT6775_CORE) += nct6775-core.o
 nct6775-objs			:= nct6775-platform.o
 obj-$(CONFIG_SENSORS_NCT6775)	+= nct6775.o

--- a/drivers/hwmon/nct6694-hwmon.c
+++ b/drivers/hwmon/nct6694-hwmon.c
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 HWMON driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/hwmon.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define DRVNAME "nct6694-hwmon"
+
+/* Host interface */
+#define REQUEST_RPT_MOD			0xFF
+#define REQUEST_HWMON_MOD		0x00
+
+/* Report Channel */
+#define HWMON_FIN_IDX(x)		(0x50 + ((x) * 2))
+#define HWMON_FIN_STS(x)		(0x6E + (x))
+#define HWMON_PWM_IDX(x)		(0x70 + (x))
+
+/* Message Channel*/
+/* Command 00h */
+#define REQUEST_HWMON_CMD0_LEN		0x40
+#define REQUEST_HWMON_CMD0_OFFSET	0x0000	/* OFFSET = SEL|CMD */
+#define HWMON_FIN_EN(x)			(0x04 + (x))
+#define HWMON_PWM_FREQ_IDX(x)		(0x30 + (x))
+/* Command 02h */
+#define REQUEST_HWMON_CMD2_LEN		0x90
+#define REQUEST_HWMON_CMD2_OFFSET	0x0002	/* OFFSET = SEL|CMD */
+#define HWMON_SMI_CTRL_IDX		0x00
+#define HWMON_FIN_LIMIT_IDX(x)		(0x70 + ((x) * 2))
+#define HWMON_CMD2_HYST_MASK		0x1F
+/* Command 03h */
+#define REQUEST_HWMON_CMD3_LEN		0x08
+#define REQUEST_HWMON_CMD3_OFFSET	0x0003	/* OFFSET = SEL|CMD */
+
+
+struct nct6694_hwmon_data {
+	struct nct6694 *nct6694;
+	struct mutex hwmon_lock;
+};
+
+#define NCT6694_HWMON_FAN_CONFIG (HWMON_F_ENABLE | HWMON_F_INPUT | \
+				  HWMON_F_MIN | HWMON_F_MIN_ALARM)
+#define NCT6694_HWMON_PWM_CONFIG (HWMON_PWM_INPUT | HWMON_PWM_FREQ)
+
+static const struct hwmon_channel_info *nct6694_info[] = {
+	HWMON_CHANNEL_INFO(fan,	NCT6694_HWMON_FAN_CONFIG,	/* FIN0 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN1 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN2 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN3 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN4 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN5 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN6 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN7 */
+				NCT6694_HWMON_FAN_CONFIG,	/* FIN8 */
+				NCT6694_HWMON_FAN_CONFIG),	/* FIN9 */
+
+	HWMON_CHANNEL_INFO(pwm, NCT6694_HWMON_PWM_CONFIG,	/* PWM0 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM1 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM2 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM3 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM4 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM5 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM6 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM7 */
+				NCT6694_HWMON_PWM_CONFIG,	/* PWM8 */
+				NCT6694_HWMON_PWM_CONFIG),	/* PWM9 */
+	NULL
+};
+
+static int nct6694_fan_read(struct device *dev, u32 attr, int channel, long *val)
+{
+	struct nct6694_hwmon_data *data = dev_get_drvdata(dev);
+	unsigned char buf[2];
+	int ret;
+
+	switch (attr) {
+	case hwmon_fan_enable:
+		ret = nct6694_getusb(data->nct6694, REQUEST_HWMON_MOD,
+				     REQUEST_HWMON_CMD0_OFFSET,
+				     REQUEST_HWMON_CMD0_LEN,
+				     HWMON_FIN_EN(channel / 8), 1, buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device! :%d", __func__, ret);
+			return -EINVAL;
+		}
+		*val = buf[0] & BIT(channel % 8) ? 1 : 0;
+		break;
+
+	case hwmon_fan_input:
+		ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
+				     HWMON_FIN_IDX(channel), 2, 0, 2, buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device!", __func__);
+			return -EINVAL;
+		}
+		*val = (buf[1] | (buf[0] << 8)) & 0xFFFF;
+		break;
+
+	case hwmon_fan_min:
+		ret = nct6694_getusb(data->nct6694, REQUEST_HWMON_MOD,
+				     REQUEST_HWMON_CMD2_OFFSET,
+				     REQUEST_HWMON_CMD2_LEN,
+				     HWMON_FIN_LIMIT_IDX(channel),
+				     2, buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device!", __func__);
+			return -EINVAL;
+		}
+		*val = (buf[1] | (buf[0] << 8)) & 0xFFFF;
+		break;
+
+	case hwmon_fan_min_alarm:
+		ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
+				     HWMON_FIN_STS(channel / 8),
+				     1, 0, 1, buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device!", __func__);
+			return -EINVAL;
+		}
+		*val = buf[0] & BIT(channel % 8);
+		break;
+
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static int nct6694_pwm_read(struct device *dev, u32 attr, int channel, long *val)
+{
+	struct nct6694_hwmon_data *data = dev_get_drvdata(dev);
+	unsigned char buf;
+	int ret;
+
+	switch (attr) {
+	case hwmon_pwm_input:
+		ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
+				     HWMON_PWM_IDX(channel),
+				     1, 0, 1, &buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device!", __func__);
+			return -EINVAL;
+		}
+		*val = buf;
+		break;
+	case hwmon_pwm_freq:
+		ret = nct6694_getusb(data->nct6694, REQUEST_HWMON_MOD,
+				     REQUEST_HWMON_CMD0_OFFSET,
+				     REQUEST_HWMON_CMD0_LEN,
+				     HWMON_PWM_FREQ_IDX(channel),
+				     1, &buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device! :%d", __func__, ret);
+			return -EINVAL;
+		}
+		*val = buf * 25000 / 255;
+
+		break;
+
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+
+static int nct6694_fan_write(struct device *dev, u32 attr, int channel, long val)
+{
+	struct nct6694_hwmon_data *data = dev_get_drvdata(dev);
+	unsigned char enable_buf[REQUEST_HWMON_CMD0_LEN] = {0};
+	unsigned char buf[REQUEST_HWMON_CMD2_LEN] = {0};
+	u16 fan_val = (u16)val;
+	int ret;
+
+	switch (attr) {
+	case hwmon_fan_enable:
+		mutex_lock(&data->hwmon_lock);
+		ret = nct6694_getusb(data->nct6694, REQUEST_HWMON_MOD,
+				     REQUEST_HWMON_CMD0_OFFSET,
+				     REQUEST_HWMON_CMD0_LEN, 0,
+				     REQUEST_HWMON_CMD0_LEN,
+				     enable_buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device!\n", __func__);
+			goto err;
+		}
+		if (val)
+			enable_buf[HWMON_FIN_EN(channel / 8)] |= BIT(channel % 8);
+		else
+			enable_buf[HWMON_FIN_EN(channel / 8)] &= ~BIT(channel % 8);
+
+		ret = nct6694_setusb_wdata(data->nct6694, REQUEST_HWMON_MOD,
+					   REQUEST_HWMON_CMD0_OFFSET,
+					   REQUEST_HWMON_CMD0_LEN,
+					   enable_buf);
+		if (ret) {
+			pr_err("%s: Failed to set hwmon device!\n", __func__);
+			goto err;
+		}
+		break;
+
+	case hwmon_fan_min:
+		mutex_lock(&data->hwmon_lock);
+		ret = nct6694_getusb(data->nct6694, REQUEST_HWMON_MOD,
+				     REQUEST_HWMON_CMD2_OFFSET,
+				     REQUEST_HWMON_CMD2_LEN, 0,
+				     REQUEST_HWMON_CMD2_LEN, buf);
+		if (ret) {
+			pr_err("%s: Failed to get hwmon device!", __func__);
+			goto err;
+		}
+		buf[HWMON_FIN_LIMIT_IDX(channel)] = (u8)((fan_val >> 8) & 0xFF);
+		buf[HWMON_FIN_LIMIT_IDX(channel) + 1] = (u8)(fan_val & 0xFF);
+		ret = nct6694_setusb_wdata(data->nct6694, REQUEST_HWMON_MOD,
+					   REQUEST_HWMON_CMD2_OFFSET,
+					   REQUEST_HWMON_CMD2_LEN, buf);
+		if (ret) {
+			pr_err("%s: Failed to set hwmon device!", __func__);
+			goto err;
+		}
+		break;
+
+	default:
+		ret = -EOPNOTSUPP;
+		goto err;
+	}
+
+err:
+	mutex_unlock(&data->hwmon_lock);
+	return ret;
+}
+
+static int nct6694_read(struct device *dev, enum hwmon_sensor_types type,
+			u32 attr, int channel, long *val)
+{
+	switch (type) {
+	case hwmon_fan:	/* in RPM */
+		return nct6694_fan_read(dev, attr, channel, val);
+
+	case hwmon_pwm:	/* in value 0~255 */
+		return nct6694_pwm_read(dev, attr, channel, val);
+
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static int nct6694_write(struct device *dev, enum hwmon_sensor_types type,
+			 u32 attr, int channel, long val)
+{
+	switch (type) {
+	case hwmon_fan:
+		return nct6694_fan_write(dev, attr, channel, val);
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static umode_t nct6694_is_visible(const void *data, enum hwmon_sensor_types type,
+				  u32 attr, int channel)
+{
+	switch (type) {
+	case hwmon_fan:
+		switch (attr) {
+		case hwmon_fan_enable:
+		case hwmon_fan_min:
+			return 0644;
+
+		case hwmon_fan_input:
+		case hwmon_fan_min_alarm:
+			return 0444;
+
+		default:
+			return 0;
+		}
+
+	case hwmon_pwm:
+		switch (attr) {
+		case hwmon_pwm_input:
+		case hwmon_pwm_freq:
+			return 0444;
+		default:
+			return 0;
+		}
+
+	default:
+		return 0;
+	}
+
+	return 0;
+}
+
+static const struct hwmon_ops nct6694_hwmon_ops = {
+	.is_visible = nct6694_is_visible,
+	.read = nct6694_read,
+	.write = nct6694_write,
+};
+
+static const struct hwmon_chip_info nct6694_chip_info = {
+	.ops = &nct6694_hwmon_ops,
+	.info = nct6694_info,
+};
+
+static int nct6694_hwmon_init(struct nct6694_hwmon_data *data)
+{
+	unsigned char buf[REQUEST_HWMON_CMD2_LEN] = {0};
+	int ret;
+
+	/* Set Fan input Real Time alarm mode */
+	mutex_lock(&data->hwmon_lock);
+	ret = nct6694_getusb(data->nct6694, REQUEST_HWMON_MOD,
+			     REQUEST_HWMON_CMD2_OFFSET,
+			     REQUEST_HWMON_CMD2_LEN, 0,
+			     REQUEST_HWMON_CMD2_LEN, buf);
+	if (ret) {
+		pr_err("%s: Failed to get HWMON registers!", __func__);
+		goto err;
+	}
+
+	buf[HWMON_SMI_CTRL_IDX] = 0x02;
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_HWMON_MOD,
+				   REQUEST_HWMON_CMD2_OFFSET,
+				   REQUEST_HWMON_CMD2_LEN, buf);
+	if (ret) {
+		pr_err("%s: Failed to set hwmon device!", __func__);
+		goto err;
+	}
+
+err:
+	mutex_unlock(&data->hwmon_lock);
+	return ret;
+}
+
+static int nct6694_hwmon_probe(struct platform_device *pdev)
+{
+	struct nct6694_hwmon_data *data;
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+	struct device *hwmon_dev;
+	int ret;
+
+	data = devm_kzalloc(&pdev->dev, sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->nct6694 = nct6694;
+	mutex_init(&data->hwmon_lock);
+	platform_set_drvdata(pdev, data);
+
+	ret = nct6694_hwmon_init(data);
+	if (ret)
+		return -EIO;
+
+	/* Register hwmon device to HWMON framework */
+	hwmon_dev = devm_hwmon_device_register_with_info(&pdev->dev,
+							 "nct6694",
+							 data,
+							 &nct6694_chip_info,
+							 NULL);
+	if (IS_ERR(hwmon_dev)) {
+		dev_err(&pdev->dev, "Failed to register hwmon device!");
+		return PTR_ERR(hwmon_dev);
+	}
+
+	dev_info(&pdev->dev, "Probe device: %s", pdev->name);
+
+	return 0;
+}
+
+static int nct6694_hwmon_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+static struct platform_driver nct6694_hwmon_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_hwmon_probe,
+	.remove		= nct6694_hwmon_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_hwmon_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_hwmon_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_hwmon_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-hwmon driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");
+

--- a/drivers/i2c/busses/Kconfig
+++ b/drivers/i2c/busses/Kconfig
@@ -880,6 +880,12 @@ config I2C_NPCM
 	  controllers.
 	  Driver can also support slave mode (select I2C_SLAVE).
 
+config I2C_NCT6694
+        tristate "Nuvoton NCT6694 I2C Adapter support"
+        depends on MFD_NCT6694
+        help
+          Say Y here to support Nuvoton NCT6694 Adapter.
+
 config I2C_OCORES
 	tristate "OpenCores I2C Controller"
 	help

--- a/drivers/i2c/busses/Makefile
+++ b/drivers/i2c/busses/Makefile
@@ -88,6 +88,7 @@ obj-$(CONFIG_I2C_MV64XXX)	+= i2c-mv64xxx.o
 obj-$(CONFIG_I2C_MXS)		+= i2c-mxs.o
 obj-$(CONFIG_I2C_NOMADIK)	+= i2c-nomadik.o
 obj-$(CONFIG_I2C_NPCM)		+= i2c-npcm7xx.o
+obj-$(CONFIG_I2C_NCT6694)	+= i2c-nct6694.o
 obj-$(CONFIG_I2C_OCORES)	+= i2c-ocores.o
 obj-$(CONFIG_I2C_OMAP)		+= i2c-omap.o
 obj-$(CONFIG_I2C_OWL)		+= i2c-owl.o

--- a/drivers/i2c/busses/i2c-nct6694.c
+++ b/drivers/i2c/busses/i2c-nct6694.c
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 I2C adapter driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define DEFAULT_BR		2
+
+/* Host interface */
+#define REQUEST_I2C_MOD		0x03
+
+/* Message Channel*/
+/* Command 00h */
+#define REQUEST_I2C_OFFSET	0x0000	/* OFFSET = SEL|CMD */
+#define REQUEST_I2C_LEN		0x90
+#define I2C_PORT_IDX		0x00
+#define I2C_BR_IDX		0x01
+#define I2C_ADDR_IDX		0x02
+#define I2C_W_CNT_IDX		0x03
+#define I2C_R_CNT_IDX		0x04
+
+#define I2C_RD_IDX		0x50
+#define I2C_WR_IDX		0x10
+
+#define DRVNAME "nct6694-i2c"
+
+#define SET_SPEED_FROM_PARAM(port, param) {	\
+	if (param >= 0 && param <= 6)	\
+		nct6694_i2c_adapter[port].priv.br = param;	\
+	else	\
+		nct6694_i2c_adapter[port].priv.br = DEFAULT_BR;  /* Default: 100K */ \
+}
+
+static int sp0 = 2;
+module_param(sp0, int, 0444);
+MODULE_PARM_DESC(sp0, "The I2C clock speed of port 0. Default:2(100K). The value can range\n"
+		      "from 0 to 6, corresponding to 25K/50K/100K/200K/400K/800K/1M\n"
+		      "respectively.\n");
+static int sp1 = 2;
+module_param(sp1, int, 0444);
+MODULE_PARM_DESC(sp1, "The I2C clock speed of port 1. Default:2(100K). The value can range\n"
+		      "from 0 to 6, corresponding to 25K/50K/100K/200K/400K/800K/1M\n"
+		      "respectively.");
+static int sp2 = 2;
+module_param(sp2, int, 0444);
+MODULE_PARM_DESC(sp2, "The I2C clock speed of port 2. Default:2(100K). The value can range\n"
+		      "from 0 to 6, corresponding to 25K/50K/100K/200K/400K/800K/1M\n"
+		      "respectively.");
+static int sp3 = 2;
+module_param(sp3, int, 0444);
+MODULE_PARM_DESC(sp3, "The I2C clock speed of port 3. Default:2(100K). The value can range\n"
+		      "from 0 to 6, corresponding to 25K/50K/100K/200K/400K/800K/1M\n"
+		      "respectively.");
+static int sp4 = 2;
+module_param(sp4, int, 0444);
+MODULE_PARM_DESC(sp4, "The I2C clock speed of port 4. Default:2(100K). The value can range\n"
+		      "from 0 to 6, corresponding to 25K/50K/100K/200K/400K/800K/1M\n"
+		      "respectively.");
+static int sp5 = 2;
+module_param(sp5, int, 0444);
+MODULE_PARM_DESC(sp5, "The I2C clock speed of port 5. Default:2(100K). The value can range\n"
+		      "from 0 to 6, corresponding to 25K/50K/100K/200K/400K/800K/1M\n"
+		      "respectively.");
+
+struct nct6694_i2c_data {
+	struct nct6694 *nct6694;
+	struct nct6694_i2c_adapter *adaps;
+	int nr_adapter;
+};
+
+struct nct6694_i2c_priv {
+	unsigned char port;
+	unsigned char br;
+};
+
+struct nct6694_i2c_adapter {
+	struct i2c_adapter adapter;
+	struct nct6694_i2c_data *data;
+
+	struct nct6694_i2c_priv priv;
+};
+
+static void fill_in_buffer(u8 port, u8 br, u8 addr, u8 w_cnt, u8 r_cnt,
+			   unsigned char *to, unsigned char *from)
+{
+	int i;
+
+	to[I2C_PORT_IDX] = port;
+	to[I2C_BR_IDX] = br;
+	to[I2C_ADDR_IDX] = addr;
+	to[I2C_W_CNT_IDX] = w_cnt;
+	to[I2C_R_CNT_IDX] = r_cnt;
+
+	for (i = 0; i < w_cnt; i++)
+		to[i + I2C_WR_IDX] = from[i];
+}
+
+static int nct6694_xfer(struct i2c_adapter *adapter, struct i2c_msg *msgs,
+			int num)
+{
+	struct nct6694_i2c_adapter *adap = adapter->algo_data;
+	struct nct6694_i2c_data *data = adap->data;
+	unsigned char buf[REQUEST_I2C_LEN] = {0};
+	int ret, i;
+
+	for (i = 0; i < num ; i++) {
+		struct i2c_msg *msg_temp = &msgs[i];
+
+		if (msg_temp->len > 64)
+			return -EPROTO;
+
+		if (msg_temp->flags & I2C_M_RD) {
+			fill_in_buffer(adap->priv.port, adap->priv.br,
+				       i2c_8bit_addr_from_msg(msg_temp), 0,
+				       msg_temp->len, buf, msg_temp->buf);
+			ret = nct6694_setusb_rdata(data->nct6694, REQUEST_I2C_MOD,
+						   REQUEST_I2C_OFFSET, REQUEST_I2C_LEN,
+						   I2C_RD_IDX, msg_temp->len, buf);
+			memcpy(msg_temp->buf, buf, msg_temp->len);
+			if (ret < 0)
+				return 0;
+		} else {
+			fill_in_buffer(adap->priv.port, adap->priv.br,
+				       i2c_8bit_addr_from_msg(msg_temp),
+				       msg_temp->len, 0, buf, msg_temp->buf);
+			ret = nct6694_setusb_wdata(data->nct6694, REQUEST_I2C_MOD,
+						   REQUEST_I2C_OFFSET, REQUEST_I2C_LEN,
+						   buf);
+			if (ret < 0)
+				return 0;
+		}
+	}
+
+	return num;
+}
+
+static u32 nct6694_func(struct i2c_adapter *adapter)
+{
+	return (I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL);
+}
+
+static const struct i2c_algorithm algorithm = {
+	.master_xfer = nct6694_xfer,
+	.functionality = nct6694_func,
+};
+
+#define NCT6694_I2C_ADAPTER(_port)	\
+{	\
+	.adapter = {	\
+		.owner = THIS_MODULE,	\
+		.algo  = &algorithm,	\
+	},	\
+	.priv = {	\
+		.port = _port	\
+	}	\
+}
+
+static struct nct6694_i2c_adapter nct6694_i2c_adapter[] = {
+	NCT6694_I2C_ADAPTER(0),
+	NCT6694_I2C_ADAPTER(1),
+	NCT6694_I2C_ADAPTER(2),
+	NCT6694_I2C_ADAPTER(3),
+	NCT6694_I2C_ADAPTER(4),
+	NCT6694_I2C_ADAPTER(5),
+};
+
+static int nct6694_i2c_probe(struct platform_device *pdev)
+{
+	struct nct6694_i2c_data *data;
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+	int i;
+
+	data = kzalloc(sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->nct6694 = nct6694;
+	data->adaps = nct6694_i2c_adapter;
+	data->nr_adapter = ARRAY_SIZE(nct6694_i2c_adapter);
+
+	//Init speed info by param or default value.
+	SET_SPEED_FROM_PARAM(0, sp0);
+	SET_SPEED_FROM_PARAM(1, sp1);
+	SET_SPEED_FROM_PARAM(2, sp2);
+	SET_SPEED_FROM_PARAM(3, sp3);
+	SET_SPEED_FROM_PARAM(4, sp4);
+	SET_SPEED_FROM_PARAM(5, sp5);
+
+	platform_set_drvdata(pdev, data);
+
+	/* Register each i2c adapter to I2C framework */
+	for (i = 0; i < data->nr_adapter; i++) {
+		struct nct6694_i2c_adapter *adapter = &data->adaps[i];
+
+		adapter->priv.port = i;
+		adapter->data = data;
+		adapter->adapter.algo_data = adapter;
+		sprintf(adapter->adapter.name, "NCT6694 I2C Adapter %d", i);
+
+		i2c_add_adapter(&data->adaps[i].adapter);
+	}
+
+	dev_info(&pdev->dev, "Probe device :%s", pdev->name);
+
+	return 0;
+}
+
+static int nct6694_i2c_remove(struct platform_device *pdev)
+{
+	struct nct6694_i2c_data *data = platform_get_drvdata(pdev);
+	int i;
+
+	for (i = 0; i < data->nr_adapter; i++)
+		i2c_del_adapter(&data->adaps[i].adapter);
+
+	kfree(data);
+
+	return 0;
+}
+
+static struct platform_driver nct6694_i2c_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_i2c_probe,
+	.remove		= nct6694_i2c_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_i2c_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_i2c_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_i2c_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-i2c adapter driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");
+

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -816,6 +816,12 @@ config NPCM_ADC
 	  This driver can also be built as a module. If so, the module
 	  will be called npcm_adc.
 
+config NCT6694_ADC
+	tristate "Nuvoton NCT6694 ADC support"
+	depends on MFD_NCT6694
+	help
+	  Say Y here to support Nuvoton NCT6694 ADC.
+
 config PALMAS_GPADC
 	tristate "TI Palmas General Purpose ADC"
 	depends on MFD_PALMAS

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -76,6 +76,7 @@ obj-$(CONFIG_MP2629_ADC) += mp2629_adc.o
 obj-$(CONFIG_MXS_LRADC_ADC) += mxs-lradc-adc.o
 obj-$(CONFIG_NAU7802) += nau7802.o
 obj-$(CONFIG_NPCM_ADC) += npcm_adc.o
+obj-$(CONFIG_NCT6694_ADC) += nct6694_adc.o
 obj-$(CONFIG_PALMAS_GPADC) += palmas_gpadc.o
 obj-$(CONFIG_QCOM_SPMI_ADC5) += qcom-spmi-adc5.o
 obj-$(CONFIG_QCOM_SPMI_IADC) += qcom-spmi-iadc.o

--- a/drivers/iio/adc/nct6694_adc.c
+++ b/drivers/iio/adc/nct6694_adc.c
@@ -1,0 +1,634 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 IIO driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/iio/iio.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define DRVNAME "nct6694-iio"
+
+/* Host interface */
+#define REQUEST_RPT_MOD		0xFF
+#define REQUEST_IIO_MOD		0x00
+
+/* Report Channel */
+#define IIO_VIN_STS(x)		(0x68 + (x))
+#define IIO_TMP_STS(x)		(0x6A + (x))
+#define IIO_TMP_STS_CH(x)	(x < 10 ? x : ((x) + 6))
+
+/* Message Channel*/
+/* Command 00h */
+#define REQUEST_IIO_CMD0_LEN	0x40
+#define REQUEST_IIO_CMD0_OFFSET	0x0000	/* OFFSET = SEL|CMD */
+#define IIO_VIN_EN(x)		(0x00 + (x))
+#define IIO_TMP_EN(x)		(0x02 + (x))
+/* Command 02h */
+#define REQUEST_IIO_CMD2_LEN	0x90
+#define REQUEST_IIO_CMD2_OFFSET	0x0002	/* OFFSET = SEL|CMD */
+#define IIO_SMI_CTRL_IDX	0x00
+#define IIO_VIN_LIMIT_IDX(x)	(0x10 + ((x) * 2))
+#define IIO_TMP_LIMIT_IDX(x)	(0x30 + ((x) * 2))
+#define IIO_CMD2_HYST_MASK	0x1F
+/* Command 03h */
+#define REQUEST_IIO_CMD3_LEN	0x08
+#define REQUEST_IIO_CMD3_OFFSET	0x0003	/* OFFSET = SEL|CMD */
+
+
+struct nct6694_iio_data {
+	struct nct6694 *nct6694;
+	struct mutex iio_lock;
+};
+
+static const struct iio_event_spec nct6694_volt_events[] = {
+	{
+		.type = IIO_EV_TYPE_THRESH,
+		.dir = IIO_EV_DIR_RISING,
+		.mask_separate = BIT(IIO_EV_INFO_VALUE) | BIT(IIO_EV_INFO_ENABLE),
+	},
+	{
+		.type = IIO_EV_TYPE_THRESH,
+		.dir = IIO_EV_DIR_FALLING,
+		.mask_separate = BIT(IIO_EV_INFO_VALUE) | BIT(IIO_EV_INFO_ENABLE),
+	}
+};
+
+static const struct iio_event_spec nct6694_temp_events[] = {
+	{
+		.type = IIO_EV_TYPE_THRESH,
+		.dir = IIO_EV_DIR_RISING,
+		.mask_separate = BIT(IIO_EV_INFO_VALUE) | BIT(IIO_EV_INFO_ENABLE),
+	}
+};
+
+#define NCT6694_VOLTAGE_CHANNEL(num, addr) { \
+	.type = IIO_VOLTAGE, \
+	.indexed = 1, \
+	.channel = num, \
+	.address = addr, \
+	.info_mask_separate = BIT(IIO_CHAN_INFO_ENABLE) | \
+			      BIT(IIO_CHAN_INFO_PROCESSED), \
+	.event_spec = nct6694_volt_events, \
+	.num_event_specs = ARRAY_SIZE(nct6694_volt_events), \
+}
+
+#define NCT6694_TEMPERATURE_CHANNEL(num, addr) { \
+	.type = IIO_TEMP, \
+	.indexed = 1, \
+	.channel = num, \
+	.address = addr, \
+	.info_mask_separate = BIT(IIO_CHAN_INFO_ENABLE) | \
+			      BIT(IIO_CHAN_INFO_PROCESSED) | \
+			      BIT(IIO_CHAN_INFO_HYSTERESIS), \
+	.event_spec = nct6694_temp_events, \
+	.num_event_specs = ARRAY_SIZE(nct6694_temp_events), \
+}
+
+static const struct iio_chan_spec nct6694_iio_channels[] = {
+	NCT6694_VOLTAGE_CHANNEL(0, 0x0),	/* VIN0 */
+	NCT6694_VOLTAGE_CHANNEL(1, 0x1),	/* VIN1 */
+	NCT6694_VOLTAGE_CHANNEL(2, 0x2),	/* VIN2 */
+	NCT6694_VOLTAGE_CHANNEL(3, 0x3),	/* VIN3 */
+	NCT6694_VOLTAGE_CHANNEL(4, 0x4),	/* VIN5 */
+	NCT6694_VOLTAGE_CHANNEL(5, 0x5),	/* VIN6 */
+	NCT6694_VOLTAGE_CHANNEL(6, 0x6),	/* VIN7 */
+	NCT6694_VOLTAGE_CHANNEL(7, 0x7),	/* VIN14 */
+	NCT6694_VOLTAGE_CHANNEL(8, 0x8),	/* VIN15 */
+	NCT6694_VOLTAGE_CHANNEL(9, 0x9),	/* VIN16 */
+	NCT6694_VOLTAGE_CHANNEL(10, 0xA),	/* VBAT */
+	NCT6694_VOLTAGE_CHANNEL(11, 0xB),	/* VSB */
+	NCT6694_VOLTAGE_CHANNEL(12, 0xC),	/* AVSB */
+	NCT6694_VOLTAGE_CHANNEL(13, 0xD),	/* VCC */
+	NCT6694_VOLTAGE_CHANNEL(14, 0xE),	/* VHIF */
+	NCT6694_VOLTAGE_CHANNEL(15, 0xF),	/* VTT */
+
+	NCT6694_TEMPERATURE_CHANNEL(0, 0x10),	/* THR1 */
+	NCT6694_TEMPERATURE_CHANNEL(1, 0x12),	/* THR2 */
+	NCT6694_TEMPERATURE_CHANNEL(2, 0x14),	/* THR14 */
+	NCT6694_TEMPERATURE_CHANNEL(3, 0x16),	/* THR15 */
+	NCT6694_TEMPERATURE_CHANNEL(4, 0x18),	/* THR16 */
+	NCT6694_TEMPERATURE_CHANNEL(5, 0x1A),	/* TDP0 */
+	NCT6694_TEMPERATURE_CHANNEL(6, 0x1C),	/* TDP1 */
+	NCT6694_TEMPERATURE_CHANNEL(7, 0x1E),	/* TDP2 */
+	NCT6694_TEMPERATURE_CHANNEL(8, 0x20),	/* TDP3 */
+	NCT6694_TEMPERATURE_CHANNEL(9, 0x22),	/* TDP4 */
+
+	NCT6694_TEMPERATURE_CHANNEL(10, 0x30),	/* DTIN0 */
+	NCT6694_TEMPERATURE_CHANNEL(11, 0x32),	/* DTIN1 */
+	NCT6694_TEMPERATURE_CHANNEL(12, 0x34),	/* DTIN2 */
+	NCT6694_TEMPERATURE_CHANNEL(13, 0x36),	/* DTIN3 */
+	NCT6694_TEMPERATURE_CHANNEL(14, 0x38),	/* DTIN4 */
+	NCT6694_TEMPERATURE_CHANNEL(15, 0x3A),	/* DTIN5 */
+	NCT6694_TEMPERATURE_CHANNEL(16, 0x3C),	/* DTIN6 */
+	NCT6694_TEMPERATURE_CHANNEL(17, 0x3E),	/* DTIN7 */
+	NCT6694_TEMPERATURE_CHANNEL(18, 0x40),	/* DTIN8 */
+	NCT6694_TEMPERATURE_CHANNEL(19, 0x42),	/* DTIN9 */
+	NCT6694_TEMPERATURE_CHANNEL(20, 0x44),	/* DTIN10 */
+	NCT6694_TEMPERATURE_CHANNEL(21, 0x46),	/* DTIN11 */
+	NCT6694_TEMPERATURE_CHANNEL(22, 0x48),	/* DTIN12 */
+	NCT6694_TEMPERATURE_CHANNEL(23, 0x4A),	/* DTIN13 */
+	NCT6694_TEMPERATURE_CHANNEL(24, 0x4C),	/* DTIN14 */
+	NCT6694_TEMPERATURE_CHANNEL(25, 0x4E),	/* DTIN15 */
+};
+
+static int nct6694_read_raw(struct iio_dev *indio_dev,
+			    struct iio_chan_spec const *chan,
+			    int *val, int *val2, long mask)
+{
+	struct nct6694_iio_data *data = iio_priv(indio_dev);
+	unsigned char buf[2], tmp_hyst, enable_idx;
+	int ret;
+
+	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+		return -EOPNOTSUPP;
+
+	switch (mask) {
+	case IIO_CHAN_INFO_ENABLE:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			enable_idx = IIO_VIN_EN(chan->channel / 8);
+			break;
+
+		case IIO_TEMP:
+			enable_idx = IIO_TMP_EN(chan->channel / 8);
+			break;
+
+		default:
+			return -EINVAL;
+		}
+		ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+				     REQUEST_IIO_CMD0_OFFSET,
+				     REQUEST_IIO_CMD0_LEN,
+				     enable_idx, 1, buf);
+		if (ret) {
+			pr_err("%s: Failed to get iio device!:%d", __func__, ret);
+			return -EINVAL;
+		}
+		*val = buf[0] & BIT(chan->channel % 8) ? 1 : 0;
+		return IIO_VAL_INT;
+
+	case IIO_CHAN_INFO_PROCESSED:
+		ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
+				     chan->address, 2, 0, 2, buf);
+		if (ret) {
+			pr_err("%s: Failed to get iio device!\n", __func__);
+			return -EINVAL;
+		}
+		switch (chan->type) {
+		case IIO_VOLTAGE:	/* in micro Voltage */
+			*val = buf[0] * 16;
+			return IIO_VAL_INT;
+
+		case IIO_TEMP:	/* in milli degrees Celsius */
+			*val = (signed char)buf[0] * 1000;
+			*val += buf[1] & 0x80 ? 500 : 0;
+			*val += buf[1] & 0x40 ? 250 : 0;
+			*val += buf[1] & 0x20 ? 125 : 0;
+
+			return IIO_VAL_INT;
+
+		default:
+			return -EINVAL;
+		}
+
+	case IIO_CHAN_INFO_HYSTERESIS:
+		ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+				     REQUEST_IIO_CMD2_OFFSET,
+				     REQUEST_IIO_CMD2_LEN,
+				     IIO_TMP_LIMIT_IDX(chan->channel),
+				     2, buf);
+		if (ret) {
+			pr_err("%s: Failed to get iio device!\n", __func__);
+			return -EINVAL;
+		}
+		switch (chan->type) {
+		case IIO_TEMP:	/* in milli degrees Celsius */
+			tmp_hyst = buf[0] >> 5;
+			*val = (buf[1] - tmp_hyst) * 1000;
+			return IIO_VAL_INT;
+
+		default:
+			return -EINVAL;
+		}
+
+	default:
+		return -EINVAL;
+	}
+}
+
+static int nct6694_write_raw(struct iio_dev *indio_dev,
+			     struct iio_chan_spec const *chan,
+			     int val, int val2, long mask)
+{
+	struct nct6694_iio_data *data = iio_priv(indio_dev);
+	unsigned char enable_buf[REQUEST_IIO_CMD0_LEN] = {0};
+	unsigned char buf[REQUEST_IIO_CMD2_LEN] = {0};
+	unsigned char delta_hyst;
+	int ret;
+
+	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+		return -EOPNOTSUPP;
+
+	switch (mask) {
+	case IIO_CHAN_INFO_ENABLE:
+		mutex_lock(&data->iio_lock);
+		ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+				     REQUEST_IIO_CMD0_OFFSET,
+				     REQUEST_IIO_CMD0_LEN, 0,
+				     REQUEST_IIO_CMD0_LEN,
+				     enable_buf);
+		if (ret) {
+			pr_err("%s: Failed to get iio device!\n", __func__);
+			goto err;
+		}
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			if (val)
+				enable_buf[IIO_VIN_EN(chan->channel / 8)] |= BIT(chan->channel % 8);
+			else
+				enable_buf[IIO_VIN_EN(chan->channel / 8)] &= ~BIT(chan->channel % 8);
+			break;
+
+		case IIO_TEMP:
+			if (val)
+				enable_buf[IIO_TMP_EN(chan->channel / 8)] |= BIT(chan->channel % 8);
+			else
+				enable_buf[IIO_TMP_EN(chan->channel / 8)] &= ~BIT(chan->channel % 8);
+			break;
+
+		default:
+			ret = -EINVAL;
+			goto err;
+		}
+		ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
+					   REQUEST_IIO_CMD0_OFFSET,
+					   REQUEST_IIO_CMD0_LEN, enable_buf);
+		if (ret) {
+			pr_err("%s: Failed to set iio device!\n", __func__);
+			goto err;
+		}
+
+		break;
+
+	case IIO_CHAN_INFO_HYSTERESIS:
+		switch (chan->type) {
+		case IIO_TEMP:
+			mutex_lock(&data->iio_lock);
+			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+					     REQUEST_IIO_CMD2_OFFSET,
+					     REQUEST_IIO_CMD2_LEN, 0,
+					     REQUEST_IIO_CMD2_LEN, buf);
+			if (ret) {
+				pr_err("Failed to get iio registers!");
+				goto err;
+			}
+
+			delta_hyst = buf[IIO_TMP_LIMIT_IDX(chan->channel) + 1] - (u8) val;
+			if (delta_hyst > 7) {
+				pr_err("%s: The Hysteresis value must be less than 7!", __func__);
+				ret = -EINVAL;
+				goto err;
+			}
+
+			buf[IIO_TMP_LIMIT_IDX(chan->channel)] &= IIO_CMD2_HYST_MASK;
+			buf[IIO_TMP_LIMIT_IDX(chan->channel)] |= (delta_hyst << 5);
+			break;
+
+		default:
+			ret = -EINVAL;
+			goto err;
+		}
+		ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
+					   REQUEST_IIO_CMD2_OFFSET,
+					   REQUEST_IIO_CMD2_LEN, buf);
+		if (ret) {
+			pr_err("%s: Failed to set iio device!\n", __func__);
+			goto err;
+		}
+
+		break;
+
+	default:
+		ret = -EINVAL;
+		goto err;
+	}
+
+err:
+	mutex_unlock(&data->iio_lock);
+	return ret;
+}
+
+static int nct6694_read_event_config(struct iio_dev *indio_dev,
+				     const struct iio_chan_spec *chan,
+				     enum iio_event_type type,
+				     enum iio_event_direction dir)
+{
+	struct nct6694_iio_data *data = iio_priv(indio_dev);
+	unsigned char buf;
+	int ret;
+
+	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+		return -EOPNOTSUPP;
+
+	switch (dir) {
+	case IIO_EV_DIR_RISING:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
+					     IIO_VIN_STS(chan->channel / 8),
+					     1, 0, 1, &buf);
+			if (ret) {
+				pr_err("%s: Failed to get iio device!\n", __func__);
+				return -EINVAL;
+			}
+			return !!(buf & BIT(chan->channel % 8));
+
+		case IIO_TEMP:
+			u8 ch = IIO_TMP_STS_CH(chan->channel);
+
+			ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
+					     IIO_TMP_STS(ch / 8),
+					     1, 0, 1, &buf);
+			if (ret) {
+				pr_err("%s: Failed to get iio device!\n", __func__);
+				return -EINVAL;
+			}
+			return !!(buf & BIT(ch % 8));
+
+		default:
+			return -EINVAL;
+		}
+
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int nct6694_read_event_value(struct iio_dev *indio_dev,
+				    const struct iio_chan_spec *chan,
+				    enum iio_event_type type,
+				    enum iio_event_direction dir,
+				    enum iio_event_info info,
+				    int *val, int *val2)
+{
+	struct nct6694_iio_data *data = iio_priv(indio_dev);
+	unsigned char buf[2];
+	int ret;
+
+	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+		return -EOPNOTSUPP;
+
+	switch (dir) {
+	case IIO_EV_DIR_RISING:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+					     REQUEST_IIO_CMD2_OFFSET,
+					     REQUEST_IIO_CMD2_LEN,
+					     IIO_VIN_LIMIT_IDX(chan->channel),
+					     2, buf);
+			if (ret) {
+				pr_err("%s: Failed to get iio device!\n", __func__);
+				return -EINVAL;
+			}
+
+			*val = buf[0] * 16;
+			return IIO_VAL_INT;
+
+		case IIO_TEMP:
+			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+					     REQUEST_IIO_CMD2_OFFSET,
+					     REQUEST_IIO_CMD2_LEN,
+					     IIO_TMP_LIMIT_IDX(chan->channel),
+					     2, buf);
+			if (ret) {
+				pr_err("%s: Failed to get iio device!\n", __func__);
+				return -EINVAL;
+			}
+
+			*val = (signed char)buf[1] * 1000;
+			return IIO_VAL_INT;
+
+		default:
+			return -EINVAL;
+		}
+
+	case IIO_EV_DIR_FALLING:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+					     REQUEST_IIO_CMD2_OFFSET,
+					     REQUEST_IIO_CMD2_LEN,
+					     IIO_VIN_LIMIT_IDX(chan->channel),
+					     2, buf);
+			if (ret) {
+				pr_err("%s: Failed to get iio device!\n", __func__);
+				return -EINVAL;
+			}
+
+			*val = buf[1] * 16;
+			return IIO_VAL_INT;
+
+		default:
+			return -EINVAL;
+		}
+
+	default:
+		return -EINVAL;
+	}
+}
+
+static int nct6694_write_event_value(struct iio_dev *indio_dev,
+				     const struct iio_chan_spec *chan,
+				     enum iio_event_type type,
+				     enum iio_event_direction dir,
+				     enum iio_event_info info,
+				     int val, int val2)
+{
+	struct nct6694_iio_data *data = iio_priv(indio_dev);
+	unsigned char buf[REQUEST_IIO_CMD2_LEN] = {0};
+	int ret;
+
+	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+		return -EOPNOTSUPP;
+
+	mutex_lock(&data->iio_lock);
+	ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+			     REQUEST_IIO_CMD2_OFFSET,
+			     REQUEST_IIO_CMD2_LEN, 0,
+			     REQUEST_IIO_CMD2_LEN, buf);
+	if (ret) {
+		pr_err("Failed to get iio registers!");
+		goto err;
+	}
+
+	switch (dir) {
+	case IIO_EV_DIR_RISING:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			buf[IIO_VIN_LIMIT_IDX(chan->channel)] = (u8) val;
+			break;
+
+		case IIO_TEMP:
+			buf[IIO_TMP_LIMIT_IDX(chan->channel) + 1] = (s8) val;
+			break;
+
+		default:
+			ret = -EINVAL;
+			goto err;
+		}
+		break;
+
+	case IIO_EV_DIR_FALLING:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			buf[IIO_VIN_LIMIT_IDX(chan->channel) + 1] = (u8) val;
+			break;
+
+		default:
+			ret = -EINVAL;
+			goto err;
+		}
+		break;
+
+	default:
+		ret = -EINVAL;
+		goto err;
+	}
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
+				   REQUEST_IIO_CMD2_OFFSET,
+				   REQUEST_IIO_CMD2_LEN, buf);
+	if (ret) {
+		pr_err("%s: Failed to set usb device!", __func__);
+		goto err;
+	}
+
+err:
+	mutex_unlock(&data->iio_lock);
+	return ret;
+}
+
+static const struct iio_info nct6694_iio_info = {
+	.read_raw = nct6694_read_raw,
+	.write_raw = nct6694_write_raw,
+	.read_event_config = nct6694_read_event_config,
+	.read_event_value = nct6694_read_event_value,
+	.write_event_value = nct6694_write_event_value,
+};
+
+static int nct6694_iio_init(struct nct6694_iio_data *data)
+{
+	unsigned char buf[REQUEST_IIO_CMD2_LEN] = {0};
+	int ret;
+
+	/* Set VIN & TMP Real Time alarm mode */
+	mutex_lock(&data->iio_lock);
+	ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
+					    REQUEST_IIO_CMD2_OFFSET,
+					    REQUEST_IIO_CMD2_LEN, 0,
+					    REQUEST_IIO_CMD2_LEN, buf);
+	if (ret) {
+		pr_err("%s: Failed to get iio registers!", __func__);
+		goto err;
+	}
+
+	buf[IIO_SMI_CTRL_IDX] = 0x02;
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
+				   REQUEST_IIO_CMD2_OFFSET,
+				   REQUEST_IIO_CMD2_LEN, buf);
+	if (ret) {
+		pr_err("%s: Failed to set iio device!", __func__);
+		goto err;
+	}
+
+err:
+	mutex_unlock(&data->iio_lock);
+	return ret;
+}
+
+static int nct6694_iio_probe(struct platform_device *pdev)
+{
+	struct iio_dev *indio_dev;
+	struct nct6694_iio_data *data;
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+	int ret;
+
+	indio_dev = devm_iio_device_alloc(&pdev->dev, sizeof(*data));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	data = iio_priv(indio_dev);
+	data->nct6694 = nct6694;
+	mutex_init(&data->iio_lock);
+	platform_set_drvdata(pdev, data);
+
+
+	ret = nct6694_iio_init(data);
+	if (ret)
+		return -EIO;
+
+	indio_dev->name = pdev->name;
+	indio_dev->channels = nct6694_iio_channels;
+	indio_dev->num_channels = ARRAY_SIZE(nct6694_iio_channels);
+	indio_dev->info = &nct6694_iio_info;
+	indio_dev->modes = INDIO_DIRECT_MODE;
+
+	/* Register iio device to IIO framework */
+	ret = devm_iio_device_register(&pdev->dev, indio_dev);
+	if (ret) {
+		dev_err(&pdev->dev, "Failed to register iio device!\n");
+		return ret;
+	}
+
+	dev_info(&pdev->dev, "Probe device :%s", pdev->name);
+
+	return 0;
+}
+
+static int nct6694_iio_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+static struct platform_driver nct6694_iio_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_iio_probe,
+	.remove		= nct6694_iio_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_iio_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_iio_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_iio_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-iio driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");
+

--- a/drivers/mfd/Kconfig
+++ b/drivers/mfd/Kconfig
@@ -408,6 +408,16 @@ config MFD_DLN2
 	  etc. must be enabled in order to use the functionality of
 	  the device.
 
+config MFD_NCT6694
+	tristate "Nuvoton NCT6694 support"
+	select MFD_CORE
+	depends on USB
+	help
+	  This adds support for Nuvoton USB device NCT6694 sharing peripherals.
+	  This includes the USB driver and core APIs.
+	  Additional drivers must be enabled in order to use the functionality
+	  of the device.
+
 config MFD_ENE_KB3930
 	tristate "ENE KB3930 Embedded Controller support"
 	depends on I2C

--- a/drivers/mfd/Makefile
+++ b/drivers/mfd/Makefile
@@ -240,6 +240,7 @@ obj-$(CONFIG_MFD_HI6421_PMIC)	+= hi6421-pmic-core.o
 obj-$(CONFIG_MFD_HI6421_SPMI)	+= hi6421-spmi-pmic.o
 obj-$(CONFIG_MFD_HI655X_PMIC)   += hi655x-pmic.o
 obj-$(CONFIG_MFD_DLN2)		+= dln2.o
+obj-$(CONFIG_MFD_NCT6694)	+= nct6694.o
 obj-$(CONFIG_MFD_RT4831)	+= rt4831.o
 obj-$(CONFIG_MFD_RT5033)	+= rt5033.o
 obj-$(CONFIG_MFD_RT5120)	+= rt5120.o

--- a/drivers/mfd/nct6694.c
+++ b/drivers/mfd/nct6694.c
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 MFD driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/io.h>
+#include <linux/usb.h>
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mfd/core.h>
+#include <linux/mfd/nct6694.h>
+
+#define DRVNAME "nct6694"
+
+/* MFD device resources */
+static const struct mfd_cell nct6694_dev[] = {
+	{
+		.name = "nct6694-gpio",
+	},
+	{
+		.name = "nct6694-i2c",
+	},
+	{
+		.name = "nct6694-canfd",
+	},
+	{
+		.name = "nct6694-wdt",
+	},
+	{
+		.name = "nct6694-iio",
+	},
+	{
+		.name = "nct6694-hwmon",
+	},
+	{
+		.name = "nct6694-pwm",
+	},
+	{
+		.name = "nct6694-rtc",
+	},
+};
+
+/*
+ * Get usb command packet
+ * - Read the data which firmware provides.
+ * - Packet format:
+ *
+ *		OUT	|RSV|MOD|CMD|SEL|HCTL|RSV|LEN_L|LEN_H|
+ *		OUT	|SEQ|STS|RSV|RSV|RSV|RSV||LEN_L|LEN_H|
+ *		IN	|-------D------A------D------A-------|
+ *			|-------D------A------D------A-------|
+ */
+int nct6694_getusb(struct nct6694 *nct6694, u8 MOD, u16 OFFSET, u16 LEN,
+		   u8 rd_idx, u8 rd_len, unsigned char *buf)
+{
+	int i, ret;
+	unsigned char err_status;
+	int len, packet_len, tx_len, rx_len;
+	struct usb_device *udev = nct6694->udev;
+
+	mutex_lock(&nct6694->access_lock);
+
+	nct6694->cmd_buffer[REQUEST_MOD_IDX] = MOD;
+	nct6694->cmd_buffer[REQUEST_CMD_IDX] = OFFSET & 0xFF;
+	nct6694->cmd_buffer[REQUEST_SEL_IDX] = (OFFSET >> 8) & 0xFF;
+	nct6694->cmd_buffer[REQUEST_HCTRL_IDX] = HCTRL_GET;
+	nct6694->cmd_buffer[REQUEST_LEN_L_IDX] = LEN & 0xFF;
+	nct6694->cmd_buffer[REQUEST_LEN_H_IDX] = (LEN >> 8) & 0xFF;
+
+	ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, BULK_OUT_ENDPOINT),
+			   nct6694->cmd_buffer, CMD_PACKET_SZ, &tx_len,
+			   nct6694->timeout);
+	if (ret)
+		goto err;
+
+	ret = usb_bulk_msg(udev, usb_rcvbulkpipe(udev, BULK_IN_ENDPOINT),
+			   nct6694->rx_buffer, CMD_PACKET_SZ, &rx_len,
+			   nct6694->timeout);
+	if (ret)
+		goto err;
+
+	err_status = nct6694->rx_buffer[RESPONSE_STS_IDX];
+
+	for (i = 0, len = LEN; len > 0; i++, len -= packet_len) {
+		if (len > nct6694->maxp)
+			packet_len = nct6694->maxp;
+		else
+			packet_len = len;
+
+		ret = usb_bulk_msg(udev, usb_rcvbulkpipe(udev, BULK_IN_ENDPOINT),
+				   nct6694->rx_buffer + nct6694->maxp * i,
+				   packet_len, &rx_len, nct6694->timeout);
+		if (ret)
+			goto err;
+	}
+
+	for (i = 0; i < rd_len; i++)
+		buf[i] = nct6694->rx_buffer[i + rd_idx];
+
+	if (err_status) {
+		pr_debug("%s: MSG CH status = %2Xh\n", __func__, err_status);
+		ret = -EIO;
+	}
+err:
+	mutex_unlock(&nct6694->access_lock);
+	return ret;
+}
+EXPORT_SYMBOL(nct6694_getusb);
+
+/*
+ * Set usb command packet
+ * - Read the data which firmware provides.
+ * - Packet format:
+ *
+ *		OUT	|RSV|MOD|CMD|SEL|HCTL|RSV|LEN_L|LEN_H|
+ *		OUT	|-------D------A------D------A-------|
+ *		IN	|SEQ|STS|RSV|RSV|RSV|RSV||LEN_L|LEN_H|
+ *		IN	|-------D------A------D------A-------|
+ *			|-------D------A------D------A-------|
+ */
+int nct6694_setusb_rdata(struct nct6694 *nct6694, u8 MOD, u16 OFFSET, u16 LEN,
+			 u8 rd_idx, u8 rd_len, unsigned char *buf)
+{
+	int i, ret;
+	unsigned char err_status;
+	int len, packet_len, tx_len, rx_len;
+	struct usb_device *udev = nct6694->udev;
+
+	mutex_lock(&nct6694->access_lock);
+
+	nct6694->cmd_buffer[REQUEST_MOD_IDX] = MOD;
+	nct6694->cmd_buffer[REQUEST_CMD_IDX] = OFFSET & 0xFF;
+	nct6694->cmd_buffer[REQUEST_SEL_IDX] = (OFFSET >> 8) & 0xFF;
+	nct6694->cmd_buffer[REQUEST_HCTRL_IDX] = HCTRL_SET;
+	nct6694->cmd_buffer[REQUEST_LEN_L_IDX] = LEN & 0xFF;
+	nct6694->cmd_buffer[REQUEST_LEN_H_IDX] = (LEN >> 8) & 0xFF;
+
+	ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, BULK_OUT_ENDPOINT),
+			   nct6694->cmd_buffer, CMD_PACKET_SZ, &tx_len,
+			   nct6694->timeout);
+	if (ret)
+		goto err;
+
+	for (i = 0, len = LEN; len > 0; i++, len -= packet_len) {
+		if (len > nct6694->maxp)
+			packet_len = nct6694->maxp;
+		else
+			packet_len = len;
+
+		memcpy(nct6694->tx_buffer + nct6694->maxp * i,
+		       buf + nct6694->maxp * i, packet_len);
+		ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, BULK_OUT_ENDPOINT),
+				   nct6694->tx_buffer + nct6694->maxp * i,
+				   packet_len, &tx_len, nct6694->timeout);
+		if (ret)
+			goto err;
+	}
+
+	ret = usb_bulk_msg(udev, usb_rcvbulkpipe(udev, BULK_IN_ENDPOINT),
+			   nct6694->rx_buffer, CMD_PACKET_SZ, &rx_len,
+			   nct6694->timeout);
+	if (ret)
+		goto err;
+
+	err_status = nct6694->rx_buffer[RESPONSE_STS_IDX];
+
+	for (i = 0, len = LEN; len > 0; i++, len -= packet_len) {
+		if (len > nct6694->maxp)
+			packet_len = nct6694->maxp;
+		else
+			packet_len = len;
+
+		ret = usb_bulk_msg(udev, usb_rcvbulkpipe(udev, BULK_IN_ENDPOINT),
+				   nct6694->rx_buffer + nct6694->maxp * i,
+				   packet_len, &rx_len, nct6694->timeout);
+		if (ret)
+			goto err;
+	}
+
+	for (i = 0; i < rd_len; i++)
+		buf[i] = nct6694->rx_buffer[i + rd_idx];
+
+	if (err_status) {
+		pr_debug("%s: MSG CH status = %2Xh\n", __func__, err_status);
+		ret = -1;
+	}
+err:
+	mutex_unlock(&nct6694->access_lock);
+	return ret;
+}
+EXPORT_SYMBOL(nct6694_setusb_rdata);
+
+/*
+ * Set usb command packet
+ * - Write data to firmware.
+ * - Packet format:
+ *
+ *		OUT	|RSV|MOD|CMD|SEL|HCTL|RSV|LEN_L|LEN_H|
+ *		OUT	|-------D------A------D------A-------|
+ *		IN	|SEQ|STS|RSV|RSV|RSV|RSV||LEN_L|LEN_H|
+ *		IN	|-------D------A------D------A-------|
+ *			|-------D------A------D------A-------|
+ */
+int nct6694_setusb_wdata(struct nct6694 *nct6694, u8 MOD, u16 OFFSET, u16 LEN,
+			 unsigned char *buf)
+{
+	int i, ret;
+	unsigned char err_status;
+	int len, packet_len, tx_len, rx_len;
+	struct usb_device *udev = nct6694->udev;
+
+	mutex_lock(&nct6694->access_lock);
+
+	nct6694->cmd_buffer[REQUEST_MOD_IDX] = MOD;
+	nct6694->cmd_buffer[REQUEST_CMD_IDX] = OFFSET & 0xFF;
+	nct6694->cmd_buffer[REQUEST_SEL_IDX] = (OFFSET >> 8) & 0xFF;
+	nct6694->cmd_buffer[REQUEST_HCTRL_IDX] = HCTRL_SET;
+	nct6694->cmd_buffer[REQUEST_LEN_L_IDX] = LEN & 0xFF;
+	nct6694->cmd_buffer[REQUEST_LEN_H_IDX] = (LEN >> 8) & 0xFF;
+
+	ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, BULK_OUT_ENDPOINT),
+			   nct6694->cmd_buffer, CMD_PACKET_SZ, &tx_len,
+			   nct6694->timeout);
+	if (ret)
+		goto err;
+
+	for (i = 0, len = LEN; len > 0; i++, len -= packet_len) {
+		if (len > nct6694->maxp)
+			packet_len = nct6694->maxp;
+		else
+			packet_len = len;
+
+		memcpy(nct6694->tx_buffer + nct6694->maxp * i,
+		       buf + nct6694->maxp * i, packet_len);
+		ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, BULK_OUT_ENDPOINT),
+				   nct6694->tx_buffer + nct6694->maxp * i,
+				   packet_len, &tx_len, nct6694->timeout);
+		if (ret)
+			goto err;
+	}
+
+	ret = usb_bulk_msg(udev, usb_rcvbulkpipe(udev, BULK_IN_ENDPOINT),
+			   nct6694->rx_buffer, CMD_PACKET_SZ, &rx_len,
+			   nct6694->timeout);
+	if (ret)
+		goto err;
+
+	err_status = nct6694->rx_buffer[RESPONSE_STS_IDX];
+
+	for (i = 0, len = LEN; len > 0; i++, len -= packet_len) {
+		if (len > nct6694->maxp)
+			packet_len = nct6694->maxp;
+		else
+			packet_len = len;
+
+		ret = usb_bulk_msg(udev, usb_rcvbulkpipe(udev, BULK_IN_ENDPOINT),
+				   nct6694->rx_buffer + nct6694->maxp * i,
+				   packet_len, &rx_len, nct6694->timeout);
+		if (ret)
+			goto err;
+	}
+
+	if (err_status) {
+		pr_debug("%s: MSG CH status = %2Xh\n", __func__, err_status);
+		ret = -1;
+	}
+err:
+	mutex_unlock(&nct6694->access_lock);
+	return ret;
+}
+EXPORT_SYMBOL(nct6694_setusb_wdata);
+
+static void setusb_work(struct work_struct *async_work)
+{
+	struct nct6694 *nct6694 = container_of(async_work, struct nct6694, async_work);
+	int ret;
+
+	ret = nct6694_setusb_wdata(nct6694, nct6694->MOD, nct6694->OFFSET,
+				   nct6694->LEN, nct6694->buf);
+}
+
+/*
+ * Set usb command packet
+ * - Write data to firmware.
+ * - Packet format:
+ *
+ *		OUT	|RSV|MOD|CMD|SEL|HCTL|RSV|LEN_L|LEN_H|
+ *		OUT	|-------D------A------D------A-------|
+ *		IN	|SEQ|STS|RSV|RSV|RSV|RSV||LEN_L|LEN_H|
+ *		IN	|-------D------A------D------A-------|
+ *			|-------D------A------D------A-------|
+ */
+void nct6694_setusb_async(struct nct6694 *nct6694, u8 MOD, u16 OFFSET, u16 LEN,
+			  unsigned char *buf)
+{
+	nct6694->MOD = MOD;
+	nct6694->OFFSET = OFFSET;
+	nct6694->LEN = LEN;
+	nct6694->buf = buf;
+	queue_work(nct6694->async_workqueue, &nct6694->async_work);
+}
+EXPORT_SYMBOL(nct6694_setusb_async);
+
+static void usb_int_callback(struct urb *urb)
+{
+	unsigned char *int_status = urb->transfer_buffer;
+	struct nct6694 *nct6694 = urb->context;
+	int ret;
+
+	switch (urb->status) {
+	case 0:
+		break;
+	case -ECONNRESET:
+	case -ENOENT:
+	case -ESHUTDOWN:
+		return;
+	default:
+		goto resubmit;
+	}
+
+	while (int_status[0]) {
+		if (int_status[0] & GPIO_IRQ_STATUS) {
+			if (nct6694->gpio_handler)
+				nct6694->gpio_handler(nct6694);
+			else
+				pr_err("The GPIO interrupt handler is unattached!");
+			int_status[0] &= ~GPIO_IRQ_STATUS;
+		} else if (int_status[0] & CAN_IRQ_STATUS) {
+			if (nct6694->can_handler)
+				nct6694->can_handler(nct6694);
+			else
+				pr_err("The CAN interrupt handler is unattached!");
+			int_status[0] &= ~CAN_IRQ_STATUS;
+		} else if (int_status[0] & RTC_IRQ_STATUS) {
+			if (nct6694->rtc_handler)
+				nct6694->rtc_handler(nct6694);
+			else {
+				pr_err("The RTC interrupt handler is unattached!");
+				int_status[0] &= ~RTC_IRQ_STATUS;
+			}
+		} else {
+			pr_debug("Unsupported irq status! :%d", int_status[0]);
+			break;
+		}
+	}
+
+resubmit:
+	ret = usb_submit_urb(urb, GFP_ATOMIC);
+	if (ret)
+		pr_debug("%s: Failed to resubmit urb, status %d", __func__, ret);
+}
+
+int nct6694_usb_probe(struct usb_interface *iface,
+		      const struct usb_device_id *id)
+{
+	struct usb_device *udev = interface_to_usbdev(iface);
+	struct usb_host_interface *interface;
+	struct usb_endpoint_descriptor *int_endpoint;
+	struct nct6694 *nct6694;
+	int ret = EINVAL;
+	int pipe, maxp, bulk_pipe;
+
+	interface = iface->cur_altsetting;
+	/* Binding interface class : 0xFF */
+	if (interface->desc.bInterfaceClass != USB_CLASS_VENDOR_SPEC ||
+		interface->desc.bInterfaceSubClass != 0x00 ||
+		interface->desc.bInterfaceProtocol != 0x00)
+		return -ENODEV;
+
+	int_endpoint = &interface->endpoint[0].desc;
+	if (!usb_endpoint_is_int_in(int_endpoint))
+		return -ENODEV;
+
+	nct6694 = devm_kzalloc(&udev->dev, sizeof(*nct6694), GFP_KERNEL);
+	if (!nct6694)
+		return -ENOMEM;
+
+	pipe = usb_rcvintpipe(udev, INT_IN_ENDPOINT);
+	maxp = usb_maxpacket(udev, pipe);
+
+	nct6694->cmd_buffer = devm_kzalloc(&udev->dev,
+					   sizeof(unsigned char) * CMD_PACKET_SZ,
+					   GFP_KERNEL);
+	if (!(nct6694->cmd_buffer))
+		return -ENOMEM;
+	nct6694->rx_buffer = devm_kzalloc(&udev->dev,
+					  sizeof(unsigned char) * MAX_PACKET_SZ,
+					  GFP_KERNEL);
+	if (!(nct6694->rx_buffer))
+		return -ENOMEM;
+	nct6694->tx_buffer = devm_kzalloc(&udev->dev,
+					  sizeof(unsigned char) * MAX_PACKET_SZ,
+					  GFP_KERNEL);
+	if (!(nct6694->tx_buffer))
+		return -ENOMEM;
+	nct6694->int_buffer = devm_kzalloc(&udev->dev,
+					   sizeof(unsigned char) * maxp,
+					   GFP_KERNEL);
+	if (!(nct6694->int_buffer))
+		return -ENOMEM;
+	nct6694->int_in_urb = usb_alloc_urb(0, GFP_KERNEL);
+	if (!(nct6694->int_in_urb)) {
+		dev_err(&udev->dev, "Failed to allocate INT-in urb!");
+		return -ENOMEM;
+	}
+
+	/* Bulk pipe maximum packet for each transaction */
+	bulk_pipe = usb_sndbulkpipe(udev, BULK_OUT_ENDPOINT);
+	nct6694->maxp = usb_maxpacket(udev, bulk_pipe);
+
+	mutex_init(&nct6694->access_lock);
+	nct6694->udev = udev;
+	nct6694->timeout = URB_TIMEOUT;	/* Wait until urb complete */
+
+	usb_fill_int_urb(nct6694->int_in_urb, udev, pipe,
+			 nct6694->int_buffer, maxp, usb_int_callback,
+			 nct6694, int_endpoint->bInterval);
+	ret = usb_submit_urb(nct6694->int_in_urb, GFP_KERNEL);
+	if (ret)
+		goto err_urb;
+
+	dev_set_drvdata(&udev->dev, nct6694);
+	usb_set_intfdata(iface, nct6694);
+
+	ret = mfd_add_hotplug_devices(&udev->dev, nct6694_dev, ARRAY_SIZE(nct6694_dev));
+	if (ret) {
+		dev_err(&udev->dev, "Failed to add mfd's child device\n");
+		goto err_mfd;
+	}
+
+	INIT_WORK(&nct6694->async_work, setusb_work);
+
+	nct6694->async_workqueue = alloc_ordered_workqueue("asyn_workqueue", 0);
+
+	dev_info(&udev->dev, "Probe device: (%04X:%04X)\n", id->idVendor, id->idProduct);
+	return 0;
+
+err_mfd:
+	usb_kill_urb(nct6694->int_in_urb);
+err_urb:
+	usb_free_urb(nct6694->int_in_urb);
+
+	return ret;
+}
+
+static void nct6694_usb_disconnect(struct usb_interface *iface)
+{
+	struct usb_device *udev = interface_to_usbdev(iface);
+	struct nct6694 *nct6694 = usb_get_intfdata(iface);
+	int ret;
+
+	mfd_remove_devices(&udev->dev);
+	ret = cancel_work_sync(&nct6694->async_work);
+	flush_workqueue(nct6694->async_workqueue);
+	destroy_workqueue(nct6694->async_workqueue);
+	usb_set_intfdata(iface, NULL);
+	usb_kill_urb(nct6694->int_in_urb);
+	usb_free_urb(nct6694->int_in_urb);
+}
+
+static const struct usb_device_id nct6694_ids[] = {
+	{ USB_DEVICE(NCT6694_VENDOR_ID, NCT6694_PRODUCT_ID)},
+	{},
+};
+MODULE_DEVICE_TABLE(usb, nct6694_ids);
+
+static struct usb_driver nct6694_usb_driver = {
+	.name	= DRVNAME,
+	.id_table = nct6694_ids,
+	.probe = nct6694_usb_probe,
+	.disconnect = nct6694_usb_disconnect,
+};
+
+module_usb_driver(nct6694_usb_driver);
+
+MODULE_DESCRIPTION("USB-MFD driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");

--- a/drivers/net/can/Kconfig
+++ b/drivers/net/can/Kconfig
@@ -182,6 +182,12 @@ config CAN_SUN4I
 	  To compile this driver as a module, choose M here: the module will
 	  be called sun4i_can.
 
+config CAN_NCT6694
+        tristate "Nuvoton NCT6694 Socket CANfd support"
+        depends on MFD_NCT6694
+        help
+          Say Y here to support Nuvoton NCT6694 Socket CANfd.
+
 config CAN_TI_HECC
 	depends on ARM
 	tristate "TI High End CAN Controller"

--- a/drivers/net/can/Makefile
+++ b/drivers/net/can/Makefile
@@ -25,6 +25,7 @@ obj-$(CONFIG_CAN_JANZ_ICAN3)	+= janz-ican3.o
 obj-$(CONFIG_CAN_KVASER_PCIEFD)	+= kvaser_pciefd.o
 obj-$(CONFIG_CAN_MSCAN)		+= mscan/
 obj-$(CONFIG_CAN_M_CAN)		+= m_can/
+obj-$(CONFIG_CAN_NCT6694)	+= nct6694_canfd.o
 obj-$(CONFIG_CAN_PEAK_PCIEFD)	+= peak_canfd/
 obj-$(CONFIG_CAN_SJA1000)	+= sja1000/
 obj-$(CONFIG_CAN_SUN4I)		+= sun4i_can.o

--- a/drivers/net/can/nct6694_canfd.c
+++ b/drivers/net/can/nct6694_canfd.c
@@ -1,0 +1,858 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 Socket CANfd driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/can/dev.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/netdevice.h>
+#include <linux/workqueue.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define NR_CAN	2
+
+#define DRVNAME "nct6694-canfd"
+
+/* Host interface */
+#define REQUEST_CAN_MOD			0x05
+
+/* Message Channel*/
+/* Command 00h */
+#define REQUEST_CAN_CMD0_LEN		0x18
+#define REQUEST_CAN_CMD0_OFFSET(idx)	(idx ? 0x0100 : 0x0000)	/* OFFSET = SEL|CMD */
+#define CAN_NBR_IDX			0x00
+#define CAN_DBR_IDX			0x04
+#define CAN_CTRL1_IDX			0x0C
+#define CAN_CTRL1_MON			BIT(0)
+#define CAN_CTRL1_NISO			BIT(1)
+#define CAN_CTRL1_LBCK			BIT(2)
+
+/* Command 01h */
+#define REQUEST_CAN_CMD1_LEN		0x08
+#define REQUEST_CAN_CMD1_OFFSET		0x0001	/* OFFSET = SEL|CMD */
+#define CAN_CLK_IDX			0x04
+#define CAN_CLK_LEN			0x04
+
+/* Command 02h */
+#define REQUEST_CAN_CMD2_LEN		0x10
+#define REQUEST_CAN_CMD2_OFFSET(idx, mask) (idx ? (0x80 | (mask & 0xFF)) << 8 | 0x02 :	\
+						  (0x00 | (mask & 0Xff)) << 8 | 0x02)	/* OFFSET = SEL|CMD */
+#define CAN_ERR_IDX(idx)		(idx ? 0x08 : 0x00)	/* Read-clear */
+#define CAN_STATUS_IDX(idx)		(idx ? 0x09 : 0x01)
+#define CAN_TX_EVT_IDX(idx)		(idx ? 0x0A : 0x02)
+#define CAN_RX_EVT_IDX(idx)		(idx ? 0x0B : 0x03)
+#define CAN_REC_IDX(idx)		(idx ? 0x0C : 0x04)
+#define CAN_TEC_IDX(idx)		(idx ? 0x0D : 0x05)
+#define CAN_EVENT_ERR			BIT(0)
+#define CAN_EVENT_STATUS		BIT(1)
+#define CAN_EVENT_TX_EVT		BIT(2)
+#define CAN_EVENT_RX_EVT		BIT(3)
+#define CAN_EVENT_REC			BIT(4)
+#define CAN_EVENT_TEC			BIT(5)
+#define CAN_EVENT_ERR_NO_ERROR		0x00	/* Read-clear */
+#define CAN_EVENT_ERR_CRC_ERROR		0x01	/* Read-clear */
+#define CAN_EVENT_ERR_STUFF_ERROR	0x02	/* Read-clear */
+#define CAN_EVENT_ERR_ACK_ERROR		0x03	/* Read-clear */
+#define CAN_EVENT_ERR_FORM_ERROR	0x04	/* Read-clear */
+#define CAN_EVENT_ERR_BIT_ERROR		0x05	/* Read-clear */
+#define CAN_EVENT_ERR_TIMEOUT_ERROR	0x06	/* Read-clear */
+#define CAN_EVENT_ERR_UNKNOWN_ERROR	0x07	/* Read-clear */
+#define CAN_EVENT_STATUS_ERROR_ACTIVE	0x00
+#define CAN_EVENT_STATUS_ERROR_PASSIVE	0x01
+#define CAN_EVENT_STATUS_BUS_OFF	0x02
+#define CAN_EVENT_STATUS_WARNING	0x03
+#define CAN_EVENT_TX_EVT_TX_FIFO_EMPTY	BIT(7)	/* Read-clear */
+#define CAN_EVENT_RX_EVT_DATA_LOST	BIT(5)	/* Read-clear */
+#define CAN_EVENT_RX_EVT_HALF_FULL	BIT(6)	/* Read-clear */
+#define CAN_EVENT_RX_EVT_DATA_IN	BIT(7)
+
+/* Command 10h */
+#define REQUEST_CAN_CMD10_LEN		0x90
+#define REQUEST_CAN_CMD10_OFFSET(buf_cnt)	((buf_cnt & 0xFF) << 8 | 0x10)	/* OFFSET = SEL|CMD */
+#define CAN_TAG_IDX			0x00
+#define CAN_FLAG_IDX			0x01
+#define CAN_DLC_IDX			0x03
+#define CAN_ID_IDX			0x04
+#define CAN_DATA_IDX			0x08
+#define CAN_TAG_CAN0			0xC0
+#define CAN_TAG_CAN1			0xC1
+#define CAN_FLAG_EFF			BIT(0)
+#define CAN_FLAG_RTR			BIT(1)
+#define CAN_FLAG_FD			BIT(2)
+#define CAN_FLAG_BRS			BIT(3)
+#define CAN_FLAG_ERR			BIT(4)
+
+/* Command 11h */
+#define REQUEST_CAN_CMD11_LEN		0x90
+#define REQUEST_CAN_CMD11_OFFSET(idx, buf_cnt) (idx ? (0x80 | (buf_cnt & 0xFF)) << 8 | 0x11 :	\
+						      (0x00 | (buf_cnt & 0Xff)) << 8 | 0x11)	/* OFFSET = SEL|CMD */
+
+#define SET_BUF16(buf, u16_val) { \
+	*(((u8 *)buf) + 0) = u16_val & 0xFF; \
+	*(((u8 *)buf) + 1) = (u16_val >> 8) & 0xFF; \
+}
+
+#define SET_BUF32(buf, u32_val) { \
+	*(((u8 *)buf) + 0) = u32_val & 0xFF; \
+	*(((u8 *)buf) + 1) = (u32_val >> 8) & 0xFF; \
+	*(((u8 *)buf) + 2) = (u32_val >> 16) & 0xFF; \
+	*(((u8 *)buf) + 3) = (u32_val >> 24) & 0xFF; \
+}
+
+struct nct6694_canfd_data {
+	struct nct6694 *nct6694;
+	struct nct6694_canfd_priv *priv;
+	struct workqueue_struct *rx_workqueue;
+	struct work_struct rx_work;
+	struct work_struct tx_work;
+	struct net_device *ndev[NR_CAN];
+	unsigned char data_buf[REQUEST_CAN_CMD10_LEN];
+};
+
+struct nct6694_canfd_priv {
+	struct can_priv can;
+	struct napi_struct napi;
+	struct nct6694_canfd_data *data;
+	unsigned char can_idx;
+};
+
+static struct nct6694_canfd_data *data;
+
+static const struct can_bittiming_const nct6694_canfd_bittiming_nominal_const = {
+	.name = DRVNAME,
+	.tseg1_min = 2,
+	.tseg1_max = 256,
+	.tseg2_min = 2,
+	.tseg2_max = 128,
+	.sjw_max = 128,
+	.brp_min = 1,
+	.brp_max = 511,
+	.brp_inc = 1,
+};
+
+static const struct can_bittiming_const nct6694_canfd_bittiming_data_const = {
+	.name = DRVNAME,
+	.tseg1_min = 1,
+	.tseg1_max = 32,
+	.tseg2_min = 1,
+	.tseg2_max = 16,
+	.sjw_max = 16,
+	.brp_min = 1,
+	.brp_max = 31,
+	.brp_inc = 1,
+};
+
+static void nct6694_canfd_set_bittiming(struct net_device *ndev, unsigned char *buf)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	const struct can_bittiming *n_bt = &priv->can.bittiming;
+	const struct can_bittiming *d_bt = &priv->can.data_bittiming;
+
+	SET_BUF32(&buf[CAN_NBR_IDX], n_bt->bitrate);
+	SET_BUF32(&buf[CAN_DBR_IDX], d_bt->bitrate);
+
+	pr_info("%s: can(%d): NBR = %d, DBR = %d\n", __func__, priv->can_idx,
+							       n_bt->bitrate,
+							       d_bt->bitrate);
+}
+
+static int nct6694_canfd_start(struct net_device *ndev)
+{
+	int ret;
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	struct nct6694_canfd_data *data = priv->data;
+	unsigned char buf[REQUEST_CAN_CMD0_LEN] = {0};
+	u16 temp = 0;
+
+	nct6694_canfd_set_bittiming(ndev, buf);
+
+	if (priv->can.ctrlmode & CAN_CTRLMODE_LISTENONLY)
+		temp |= CAN_CTRL1_MON;
+
+	if ((priv->can.ctrlmode & CAN_CTRLMODE_FD) &&
+		 priv->can.ctrlmode & CAN_CTRLMODE_FD_NON_ISO)
+		temp |= CAN_CTRL1_NISO;
+
+	if (priv->can.ctrlmode & CAN_CTRLMODE_LOOPBACK)
+		temp |= CAN_CTRL1_LBCK;
+
+	SET_BUF16(&buf[CAN_CTRL1_IDX], temp);
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_CAN_MOD,
+				   REQUEST_CAN_CMD0_OFFSET(priv->can_idx),
+				   REQUEST_CAN_CMD0_LEN, buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to set data bittiming\n", __func__);
+		return ret;
+	}
+
+	priv->can.state = CAN_STATE_ERROR_ACTIVE;
+
+	return 0;
+}
+
+static void nct6694_canfd_stop(struct net_device *ndev)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+
+	priv->can.state = CAN_STATE_STOPPED;
+}
+
+static int nct6694_canfd_set_mode(struct net_device *ndev, enum can_mode mode)
+{
+	switch (mode) {
+	case CAN_MODE_START:
+		nct6694_canfd_start(ndev);
+		netif_wake_queue(ndev);
+		break;
+
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static int nct6694_canfd_get_berr_counter(const struct net_device *ndev,
+					  struct can_berr_counter *bec)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	struct nct6694_canfd_data *data = priv->data;
+	unsigned char mask = CAN_EVENT_REC | CAN_EVENT_TEC;
+	unsigned char buf[REQUEST_CAN_CMD2_LEN] = {0};
+	int ret;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_CAN_MOD,
+			     REQUEST_CAN_CMD2_OFFSET(priv->can_idx, mask),
+			     REQUEST_CAN_CMD2_LEN, 0x00, REQUEST_CAN_CMD2_LEN,
+			     (unsigned char *)&buf);
+	if (ret < 0) {
+		pr_err("%s: Failed to get data from usb device!\n", __func__);
+		return -EINVAL;
+	}
+
+	bec->rxerr = buf[CAN_REC_IDX(priv->can_idx)];
+	bec->txerr = buf[CAN_TEC_IDX(priv->can_idx)];
+
+	return 0;
+}
+
+static int nct6694_canfd_open(struct net_device *ndev)
+{
+	int ret;
+
+	ret = open_candev(ndev);
+	if (ret)
+		return ret;
+
+	ret = nct6694_canfd_start(ndev);
+	if (ret) {
+		pr_err("%s: Failed to start CAN controller\n", __func__);
+		close_candev(ndev);
+		return ret;
+	}
+
+	netif_start_queue(ndev);
+
+	return 0;
+}
+
+static int nct6694_canfd_close(struct net_device *ndev)
+{
+	netif_stop_queue(ndev);
+	nct6694_canfd_stop(ndev);
+	close_candev(ndev);
+
+	return 0;
+}
+
+static netdev_tx_t nct6694_canfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	int can_idx = priv->can_idx;
+	struct canfd_frame *cf = (struct canfd_frame *)skb->data;
+	struct net_device_stats *stats = &ndev->stats;
+	u32 txid = 0;
+	int i;
+	unsigned int echo_byte;
+	u8 data_buf[REQUEST_CAN_CMD10_LEN] = {0};
+
+	if (can_dropped_invalid_skb(ndev, skb))
+		return NETDEV_TX_OK;
+
+	/* Check if the TX buffer is full */
+	/* No check for NCT6694 because the TX bit is read-clear and may be read-cleared by other function. */
+	/* Just check the result of tx command. */
+
+	netif_stop_queue(ndev);
+
+	/* set the index of CAN dev */
+	if (can_idx == 0)
+		data_buf[CAN_TAG_IDX] = CAN_TAG_CAN0;
+	else
+		data_buf[CAN_TAG_IDX] = CAN_TAG_CAN1;
+
+	if (cf->can_id & CAN_EFF_FLAG) {
+		txid = cf->can_id & CAN_EFF_MASK;
+		/*
+		 * In case the Extended ID frame is transmitted, the
+		 * standard and extended part of the ID are swapped
+		 * in the register, so swap them back to send the
+		 * correct ID.
+		 */
+		data_buf[CAN_FLAG_IDX] |= CAN_FLAG_EFF;
+
+	} else
+		txid = cf->can_id & CAN_SFF_MASK;
+
+	SET_BUF32(&data_buf[CAN_ID_IDX], txid);
+
+	data_buf[CAN_DLC_IDX] = cf->len;
+
+	if ((priv->can.ctrlmode & CAN_CTRLMODE_FD) && can_is_canfd_skb(skb)) {
+		data_buf[CAN_FLAG_IDX] |= CAN_FLAG_FD;
+		if (cf->flags & CANFD_BRS)
+			data_buf[CAN_FLAG_IDX] |= CAN_FLAG_BRS;
+	}
+
+	if (cf->can_id & CAN_RTR_FLAG)
+		data_buf[CAN_FLAG_IDX] |= CAN_FLAG_RTR;
+
+	/* set data to buf */
+	for (i = 0; i < cf->len; i++)
+		data_buf[CAN_DATA_IDX + i] = *(u8 *)(cf->data + i);
+
+	can_put_echo_skb(skb, ndev, 0, 0);
+
+	memcpy(data->data_buf, data_buf, REQUEST_CAN_CMD10_LEN);
+	queue_work(data->rx_workqueue, &data->tx_work);
+
+	stats->tx_bytes += cf->len;
+	stats->tx_packets++;
+	echo_byte = can_get_echo_skb(ndev, 0, NULL);
+
+	netif_wake_queue(ndev);
+
+	return NETDEV_TX_OK;
+}
+
+static void nct6694_canfd_tx_work(struct work_struct *work)
+{
+	int ret;
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_CAN_MOD,
+				   REQUEST_CAN_CMD10_OFFSET(1),
+				   REQUEST_CAN_CMD10_LEN, data->data_buf);
+}
+
+static int nuv_canfd_handle_lost_msg(struct net_device *ndev)
+{
+	struct net_device_stats *stats = &ndev->stats;
+	struct sk_buff *skb;
+	struct can_frame *frame;
+
+	netdev_err(ndev, "RX FIFO overflow, message(s) lost.\n");
+
+	stats->rx_errors++;
+	stats->rx_over_errors++;
+
+	skb = alloc_can_err_skb(ndev, &frame);
+	if (unlikely(!skb))
+		return 0;
+
+	pr_info("%s: CAN_ERR_CRTL_RX_OVERFLOW\r\n", __func__);
+
+	frame->can_id |= CAN_ERR_CRTL;
+	frame->data[1] = CAN_ERR_CRTL_RX_OVERFLOW;
+
+	netif_receive_skb(skb);
+
+	return 1;
+}
+
+static void nuv_canfd_read_fifo(struct net_device *ndev)
+{
+	struct net_device_stats *stats = &ndev->stats;
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	int can_idx = priv->can_idx;
+	struct canfd_frame *cf;
+	struct sk_buff *skb;
+	u32 id;
+	int ret;
+	u8 data_buf[REQUEST_CAN_CMD11_LEN] = {0};
+	u8 fd_format = 0;
+	int i;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_CAN_MOD,
+			     REQUEST_CAN_CMD11_OFFSET(can_idx, 1),
+			     REQUEST_CAN_CMD11_LEN, 0, REQUEST_CAN_CMD11_LEN,
+			     data_buf);
+	if (ret < 0)
+		pr_err("%s: Failed to get usb message: %d\n", __func__, ret);
+
+	/* Check type of frame and create skb */
+	fd_format = data_buf[CAN_FLAG_IDX] & CAN_FLAG_FD;
+	if (fd_format)
+		skb = alloc_canfd_skb(ndev, &cf);
+	else
+		skb = alloc_can_skb(ndev, (struct can_frame **)&cf);
+
+	if (!skb) {
+		stats->rx_dropped++;
+		return;
+	}
+
+	/* Get length */
+	cf->len = data_buf[CAN_DLC_IDX];
+
+	/* Get ID and set flag by its type(Standard ID format or Ext ID format) */
+	id = le32_to_cpu(*(u32 *)(&data_buf[CAN_ID_IDX]));
+	if (data_buf[CAN_FLAG_IDX] & CAN_FLAG_EFF) {
+		/*
+		 * In case the Extended ID frame is received, the standard
+		 * and extended part of the ID are swapped in the register,
+		 * so swap them back to obtain the correct ID.
+		 */
+		id |= CAN_EFF_FLAG;
+	}
+
+	cf->can_id = id;
+
+	/* Set ESI flag */
+	if (data_buf[CAN_FLAG_IDX] & CAN_FLAG_ERR) {
+		cf->flags |= CANFD_ESI;
+		netdev_dbg(ndev, "ESI Error\n");
+	}
+
+	/* Set RTR and BRS */
+	if (!fd_format &&
+	    (data_buf[CAN_FLAG_IDX] & CAN_FLAG_RTR)) {
+		cf->can_id |= CAN_RTR_FLAG;
+	} else {
+		if (data_buf[CAN_FLAG_IDX] & CAN_FLAG_BRS)
+			cf->flags |= CANFD_BRS;
+
+		/* Read data from HW */
+		for (i = 0; i < cf->len; i++)
+			*(u8 *)(cf->data+i) = data_buf[CAN_DATA_IDX + i];
+	}
+
+	/* Remove the packet from FIFO */
+	stats->rx_packets++;
+	stats->rx_bytes += cf->len;
+
+	netif_receive_skb(skb);
+}
+
+
+static int nct6694_canfd_do_rx_poll(struct net_device *ndev, int quota)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	int can_idx = priv->can_idx;
+	int ret;
+	u32 pkts = 0;
+	u8 data_buf_can_evt[REQUEST_CAN_CMD2_LEN] = {0};
+	u8 mask_rx = CAN_EVENT_RX_EVT;
+	u8 rx_evt;
+
+	for (;;) {
+		ret = nct6694_getusb(data->nct6694, REQUEST_CAN_MOD,
+				     REQUEST_CAN_CMD2_OFFSET(can_idx, mask_rx),
+				     REQUEST_CAN_CMD2_LEN, 0, REQUEST_CAN_CMD2_LEN,
+				     data_buf_can_evt);
+		if (ret < 0)
+			pr_err("%s: Failed to get usb message: %d\n", __func__, ret);
+
+		/* Handle lost messages when handling RX because it is read-cleared reg */
+		rx_evt = data_buf_can_evt[CAN_RX_EVT_IDX(can_idx)];
+		if (rx_evt & CAN_EVENT_RX_EVT_DATA_LOST)
+			nuv_canfd_handle_lost_msg(ndev);
+
+		if ((rx_evt & CAN_EVENT_RX_EVT_DATA_IN) == 0) /* No data */
+			break;
+
+		if (quota <= 0)
+			break;
+
+		nuv_canfd_read_fifo(ndev);
+		quota--;
+		pkts++;
+	}
+
+	return pkts;
+}
+
+static int nct6694_canfd_handle_lec_err(struct net_device *ndev, u8 bus_err)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+
+	int can_idx = priv->can_idx;
+	struct net_device_stats *stats = &ndev->stats;
+	struct can_frame *cf;
+	struct sk_buff *skb;
+
+	if (bus_err == CAN_EVENT_ERR_NO_ERROR)
+		return 0;
+
+	pr_info("%s: d:%d\r\n", __func__,  can_idx);
+
+	priv->can.can_stats.bus_error++;
+	stats->rx_errors++;
+
+	/* Propagate the error condition to the CAN stack. */
+	skb = alloc_can_err_skb(ndev, &cf);
+	if (unlikely(!skb))
+		return 0;
+
+	/* Read the error counter register and check for new errors. */
+	cf->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR;
+
+
+	switch (bus_err) {
+	case CAN_EVENT_ERR_CRC_ERROR:
+		cf->data[3] = CAN_ERR_PROT_LOC_CRC_SEQ;
+		break;
+
+	case CAN_EVENT_ERR_STUFF_ERROR:
+		cf->data[2] |= CAN_ERR_PROT_STUFF;
+		break;
+
+	case CAN_EVENT_ERR_ACK_ERROR:
+		cf->data[3] = CAN_ERR_PROT_LOC_ACK;
+		break;
+
+	case CAN_EVENT_ERR_FORM_ERROR:
+		cf->data[2] |= CAN_ERR_PROT_FORM;
+		break;
+
+	case CAN_EVENT_ERR_BIT_ERROR:
+		cf->data[2] |= CAN_ERR_PROT_BIT | CAN_ERR_PROT_BIT0 | CAN_ERR_PROT_BIT1;
+		break;
+
+	case CAN_EVENT_ERR_TIMEOUT_ERROR:
+		cf->data[2] |= CAN_ERR_PROT_UNSPEC;
+		break;
+
+	case CAN_EVENT_ERR_UNKNOWN_ERROR:
+		cf->data[2] |= CAN_ERR_PROT_UNSPEC;
+		/* It means 'unspecified'(the value is '0'). But it is not sure if it's ok to send an error package without specific error bit. */
+		break;
+
+	default:
+		break;
+	}
+
+	/* Reset the error counter, ack the IRQ and re-enable the counter. */
+	/* Read-cleared. Do nothing. */
+	stats->rx_packets++;
+	stats->rx_bytes += cf->can_dlc;
+	netif_receive_skb(skb);
+
+	return 1;
+}
+
+static int nct6694_canfd_handle_state_change(struct net_device *ndev,
+					 enum can_state new_state)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	struct net_device_stats *stats = &ndev->stats;
+	struct can_frame *cf;
+	struct sk_buff *skb;
+	struct can_berr_counter bec;
+
+	pr_info("%s: \r\n", __func__);
+
+	switch (new_state) {
+	case CAN_STATE_ERROR_ACTIVE:
+		/* error active state */
+		priv->can.can_stats.error_warning++;
+		priv->can.state = CAN_STATE_ERROR_ACTIVE;
+		break;
+	case CAN_STATE_ERROR_WARNING:
+		/* error warning state */
+		priv->can.can_stats.error_warning++;
+		priv->can.state = CAN_STATE_ERROR_WARNING;
+		break;
+	case CAN_STATE_ERROR_PASSIVE:
+		/* error passive state */
+		priv->can.can_stats.error_passive++;
+		priv->can.state = CAN_STATE_ERROR_PASSIVE;
+		break;
+	case CAN_STATE_BUS_OFF:
+		/* bus-off state */
+		priv->can.state = CAN_STATE_BUS_OFF;
+		priv->can.can_stats.bus_off++;
+		can_bus_off(ndev);
+		break;
+	default:
+		break;
+	}
+
+	/* propagate the error condition to the CAN stack */
+	skb = alloc_can_err_skb(ndev, &cf);
+	if (unlikely(!skb))
+		return 0;
+
+	nct6694_canfd_get_berr_counter(ndev, &bec);
+
+	switch (new_state) {
+	case CAN_STATE_ERROR_WARNING:
+		/* error warning state */
+		cf->can_id |= CAN_ERR_CRTL;
+		cf->data[1] = (bec.txerr > bec.rxerr) ? CAN_ERR_CRTL_TX_WARNING :
+							CAN_ERR_CRTL_RX_WARNING;
+		cf->data[6] = bec.txerr;
+		cf->data[7] = bec.rxerr;
+		break;
+	case CAN_STATE_ERROR_PASSIVE:
+		/* error passive state */
+		cf->can_id |= CAN_ERR_CRTL;
+		cf->data[1] |= CAN_ERR_CRTL_RX_PASSIVE;
+		if (bec.txerr > 127)
+			cf->data[1] |= CAN_ERR_CRTL_TX_PASSIVE;
+		cf->data[6] = bec.txerr;
+		cf->data[7] = bec.rxerr;
+		break;
+	case CAN_STATE_BUS_OFF:
+		/* bus-off state */
+		cf->can_id |= CAN_ERR_BUSOFF;
+		break;
+	default:
+		break;
+	}
+
+	stats->rx_packets++;
+	stats->rx_bytes += cf->can_dlc;
+	netif_receive_skb(skb);
+
+	return 1;
+}
+
+static int nct6694_canfd_handle_state_errors(struct net_device *ndev, u8 *can_evt_buf)
+{
+	struct nct6694_canfd_priv *priv = netdev_priv(ndev);
+	int can_idx = priv->can_idx;
+	//u32 stcmd = readl(priv->base + NUV_CANFD_STCMD);
+	int work_done = 0;
+	u8 can_status;
+
+	can_status = can_evt_buf[CAN_STATUS_IDX(can_idx)];
+
+	if ((can_status == CAN_EVENT_STATUS_ERROR_ACTIVE) &&
+	    (priv->can.state != CAN_STATE_ERROR_ACTIVE)) {
+		netdev_dbg(ndev, "Error, entered active state\n");
+		work_done += nct6694_canfd_handle_state_change(ndev,
+							       CAN_STATE_ERROR_ACTIVE);
+	}
+
+	if ((can_status == CAN_EVENT_STATUS_WARNING) &&
+	    (priv->can.state != CAN_STATE_ERROR_WARNING)) {
+		netdev_dbg(ndev, "Error, entered warning state\n");
+		work_done += nct6694_canfd_handle_state_change(ndev,
+							       CAN_STATE_ERROR_WARNING);
+	}
+
+	if ((can_status == CAN_EVENT_STATUS_ERROR_PASSIVE) &&
+	    (priv->can.state != CAN_STATE_ERROR_PASSIVE)) {
+		netdev_dbg(ndev, "Error, entered passive state\n");
+		work_done += nct6694_canfd_handle_state_change(ndev,
+							       CAN_STATE_ERROR_PASSIVE);
+	}
+
+	if ((can_status == CAN_EVENT_STATUS_BUS_OFF) &&
+	    (priv->can.state != CAN_STATE_BUS_OFF)) {
+		netdev_dbg(ndev, "Error, entered bus-off state\n");
+		work_done += nct6694_canfd_handle_state_change(ndev,
+							       CAN_STATE_BUS_OFF);
+	}
+
+	return work_done;
+}
+
+#define RX_QUATA	64
+static void nct6694_canfd_rx_work(struct work_struct *work)
+{
+	struct nct6694_canfd_priv *priv;
+	struct net_device *ndev;
+	struct net_device_stats *stats;
+	int i, ret;
+	int can_idx;
+	int work_done = 0;
+	int quota = RX_QUATA;
+	u8 data_buf_can_evt[REQUEST_CAN_CMD2_LEN] = {0};
+	u8 bus_err;
+	u8 mask_sts = CAN_EVENT_ERR | CAN_EVENT_STATUS;
+
+	for (i = 0; i < NR_CAN; i++) {
+		ndev = data->ndev[i];
+		priv = netdev_priv(ndev);
+		can_idx = priv->can_idx;
+		stats = &ndev->stats;
+
+		ret = nct6694_getusb(data->nct6694, REQUEST_CAN_MOD,
+				     REQUEST_CAN_CMD2_OFFSET(can_idx, mask_sts),
+				     REQUEST_CAN_CMD2_LEN, 0, REQUEST_CAN_CMD2_LEN,
+				     data_buf_can_evt);
+		if (ret < 0)
+			pr_err("%s: Failed to get usb message\n", __func__);
+
+		/* Handle bus state changes */
+		work_done += nct6694_canfd_handle_state_errors(ndev, data_buf_can_evt);
+
+		/* Handle lec errors on the bus */
+		if (priv->can.ctrlmode & CAN_CTRLMODE_BERR_REPORTING) {
+			bus_err = data_buf_can_evt[CAN_ERR_IDX(can_idx)];
+			work_done += nct6694_canfd_handle_lec_err(ndev, bus_err);
+		}
+
+		/* Check data lost and handle normal messages on RX.
+		 *  Don't check rx fifo-empty here because the data-lost bit in the same reg is read-cleared,
+		 *  we handle it when handling rx event
+		 */
+
+		work_done += nct6694_canfd_do_rx_poll(ndev, quota - work_done);
+	}
+}
+
+void nct6694_start_rx(struct nct6694 *nct6694)
+{
+	queue_work(data->rx_workqueue, &data->rx_work);
+}
+
+static const struct net_device_ops nct6694_canfd_netdev_ops = {
+	.ndo_open = nct6694_canfd_open,
+	.ndo_stop = nct6694_canfd_close,
+	.ndo_start_xmit = nct6694_canfd_start_xmit,
+	.ndo_change_mtu = can_change_mtu,
+};
+
+static int nct6694_canfd_probe(struct platform_device *pdev)
+{
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+	unsigned int can_clk;
+	int i, j;
+	int ret;
+
+	data = kzalloc(sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	ret = nct6694_getusb(nct6694, REQUEST_CAN_MOD, REQUEST_CAN_CMD1_OFFSET,
+			     REQUEST_CAN_CMD1_LEN, CAN_CLK_IDX, CAN_CLK_LEN,
+			     (unsigned char *)&can_clk);
+	if (ret < 0) {
+		pr_err("%s: Failed to get usb message\n", __func__);
+		return -EINVAL;
+	}
+	pr_info("can_clk = %d\n", le32_to_cpu(can_clk));
+
+	nct6694->can_handler = nct6694_start_rx;
+
+	data->nct6694 = nct6694;
+	data->rx_workqueue = create_singlethread_workqueue("rx_workqueue");
+	INIT_WORK(&data->rx_work, nct6694_canfd_rx_work);
+	INIT_WORK(&data->tx_work, nct6694_canfd_tx_work);
+
+	for (i = 0; i < NR_CAN; i++) {
+		struct nct6694_canfd_priv *priv;
+
+		data->ndev[i] = alloc_candev(sizeof(*priv), 1);
+		if (!data->ndev[i])
+			return -ENOMEM;
+
+		data->ndev[i]->flags |= IFF_ECHO;
+		data->ndev[i]->netdev_ops = &nct6694_canfd_netdev_ops;
+
+		priv = netdev_priv(data->ndev[i]);
+		priv->data = data;
+		priv->can_idx = i;
+
+		priv->can.state = CAN_STATE_STOPPED;
+		priv->can.clock.freq = le32_to_cpu(can_clk);
+		priv->can.bittiming_const = &nct6694_canfd_bittiming_nominal_const;
+		priv->can.data_bittiming_const = &nct6694_canfd_bittiming_data_const;
+		priv->can.do_set_mode = nct6694_canfd_set_mode;
+		priv->can.do_get_berr_counter = nct6694_canfd_get_berr_counter;
+
+		priv->can.ctrlmode = CAN_CTRLMODE_FD;
+
+		priv->can.ctrlmode_supported = CAN_CTRLMODE_LOOPBACK	|
+					       CAN_CTRLMODE_LISTENONLY	|
+					       CAN_CTRLMODE_FD		|
+					       CAN_CTRLMODE_FD_NON_ISO	|
+					       CAN_CTRLMODE_BERR_REPORTING;
+
+		SET_NETDEV_DEV(data->ndev[i], &pdev->dev);
+
+		ret = register_candev(data->ndev[i]);
+		if (ret) {
+			dev_err(&pdev->dev, "register_candev failed: %d", ret);
+			goto err;
+		}
+	}
+	queue_work(data->rx_workqueue, &data->rx_work);
+
+	dev_info(&pdev->dev, "Probe device :%s", pdev->name);
+
+	return 0;
+
+err:
+	for (j = 0; j < i; j++) {
+		unregister_candev(data->ndev[i]);
+		free_candev(data->ndev[i]);
+	}
+	return -ENOMEM;
+}
+
+static int nct6694_canfd_remove(struct platform_device *pdev)
+{
+	int i, ret;
+
+	ret = cancel_work_sync(&data->rx_work);
+	flush_workqueue(data->rx_workqueue);
+	destroy_workqueue(data->rx_workqueue);
+
+	for (i = 0; i < NR_CAN; i++) {
+		unregister_candev(data->ndev[i]);
+		free_candev(data->ndev[i]);
+	}
+
+	return 0;
+}
+
+static struct platform_driver nct6694_canfd_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_canfd_probe,
+	.remove		= nct6694_canfd_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_canfd_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_canfd_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_canfd_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-CAN FD driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -412,6 +412,12 @@ config PWM_NTXEC
 	  controller found in certain e-book readers designed by the original
 	  design manufacturer Netronix.
 
+config PWM_NCT6694
+	tristate "Nuvoton NCT6694 PWM controller support"
+	depends on MFD_NCT6694
+	help
+	  Say Y here to support Nuvoton NCT6694 controller.
+
 config PWM_OMAP_DMTIMER
 	tristate "OMAP Dual-Mode Timer PWM support"
 	depends on OF

--- a/drivers/pwm/Makefile
+++ b/drivers/pwm/Makefile
@@ -37,6 +37,7 @@ obj-$(CONFIG_PWM_MEDIATEK)	+= pwm-mediatek.o
 obj-$(CONFIG_PWM_MTK_DISP)	+= pwm-mtk-disp.o
 obj-$(CONFIG_PWM_MXS)		+= pwm-mxs.o
 obj-$(CONFIG_PWM_NTXEC)		+= pwm-ntxec.o
+obj-$(CONFIG_PWM_NCT6694)	+= pwm-nct6694.o
 obj-$(CONFIG_PWM_OMAP_DMTIMER)	+= pwm-omap-dmtimer.o
 obj-$(CONFIG_PWM_PCA9685)	+= pwm-pca9685.o
 obj-$(CONFIG_PWM_PXA)		+= pwm-pxa.o

--- a/drivers/pwm/pwm-nct6694.c
+++ b/drivers/pwm/pwm-nct6694.c
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 PWM driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/pwm.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define DRVNAME "nct6694-pwm"
+
+#define NR_PWM	10
+#define MAX_PERIOD_NS	40000	/* PWM Maximum Frequency = 25kHz*/
+#define PERIOD_NS_CONST	10200000	/* Period_ns to Freq_reg */
+
+/* Host interface */
+#define REQUEST_RPT_MOD			0xFF
+#define REQUEST_HWMON_MOD		0x00
+#define REQUEST_PWM_MOD			0x01
+
+/* Report Channel */
+#define HWMON_PWM_IDX(x)		(0x70 + (x))
+
+/* Message Channel -HWMON */
+/* Command 00h */
+#define REQUEST_HWMON_CMD0_LEN		0x40
+#define REQUEST_HWMON_CMD0_OFFSET	0x0000	/* OFFSET = SEL|CMD */
+#define HWMON_PWM_EN(x)			(0x06 + (x))
+#define HWMON_PWM_PP(x)			(0x08 + (x))
+#define HWMON_PWM_FREQ_IDX(x)		(0x30 + (x))
+
+/* Message Channel -FAN */
+/* Command 00h */
+#define REQUEST_PWM_CMD0_LEN		0x08
+#define REQUEST_PWM_CMD0_OFFSET		0x0000	/* OFFSET = SEL|CMD */
+#define PWM_CH_EN(x)			(x ? 0x00 : 0x01)
+/* Command 01h */
+#define REQUEST_PWM_CMD1_LEN		0x20
+#define REQUEST_PWM_CMD1_OFFSET		0x0001	/* OFFSET = SEL|CMD */
+#define PWM_MAL_EN(x)			(x ? 0x00 : 0x01)
+#define PWM_MAL_VAL(x)			(0x02 + (x))
+
+/*
+ *		Frequency <-> Period
+ * (10^9 * 255) / (25000 * Freq_reg) = Period_ns
+ *		10200000 / Freq_reg			 = Period_ns
+ *
+ * | Freq_reg | Freq_Hz | Period_ns |
+ * |  1 (01h  |  98.039 |  10200000 |
+ * |  2 (02h) | 196.078 |   5100000 |
+ * |  3 (03h) | 294.117 |   3400000 |
+ * |		  ...		    |
+ * |		  ...		    |
+ * |		  ...		    |
+ * | 253 (FDh)| 24803.9 |  40316.20 |
+ * | 254 (FEh)| 24901.9 |  40157.48 |
+ * | 255 (FFh)|  25000  |    40000  |
+ *
+ */
+
+struct nct6694_pwm_data {
+	struct nct6694 *nct6694;
+	struct pwm_chip chip;
+
+	unsigned char hwmon_cmd0_buf[REQUEST_HWMON_CMD0_LEN];
+	unsigned char pwm_cmd0_buf[REQUEST_PWM_CMD0_LEN];
+	unsigned char pwm_cmd1_buf[REQUEST_PWM_CMD1_LEN];
+};
+
+static inline struct nct6694_pwm_data *to_nct6694_pwm_data(struct pwm_chip *chip)
+{
+	return container_of(chip, struct nct6694_pwm_data, chip);
+}
+
+static int nct6694_pwm_request(struct pwm_chip *chip, struct pwm_device *pwm)
+{
+	struct nct6694_pwm_data *data = to_nct6694_pwm_data(chip);
+	unsigned char ch_enable = data->pwm_cmd0_buf[PWM_CH_EN(pwm->hwpwm / 8)];
+	unsigned char mal_enable = data->pwm_cmd1_buf[PWM_MAL_EN(pwm->hwpwm / 8)];
+	bool ch_en = ch_enable & BIT(pwm->hwpwm % 8);
+	bool mal_en = mal_enable & BIT(pwm->hwpwm % 8);
+
+	if (!(ch_en && mal_en)) {
+		pr_err("%s: PWM(%d) is running in other mode!", __func__, pwm->hwpwm);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int nct6694_pwm_get_state(struct pwm_chip *chip,
+				 struct pwm_device *pwm,
+				 struct pwm_state *state)
+{
+	struct nct6694_pwm_data *data = to_nct6694_pwm_data(chip);
+	unsigned char freq_reg, duty;
+
+	/* Get pwm device initial state */
+	state->enabled = true;
+
+	freq_reg = data->hwmon_cmd0_buf[HWMON_PWM_FREQ_IDX(pwm->hwpwm)];
+	state->period = PERIOD_NS_CONST / freq_reg;
+
+	duty = data->pwm_cmd1_buf[PWM_MAL_VAL(pwm->hwpwm)];
+	state->duty_cycle = duty * state->period / 0xFF;
+
+	return 0;
+}
+
+static int nct6694_pwm_apply(struct pwm_chip *chip,
+			     struct pwm_device *pwm,
+			     const struct pwm_state *state)
+{
+	struct nct6694_pwm_data *data = to_nct6694_pwm_data(chip);
+	unsigned char freq_reg, duty;
+	int ret;
+
+	if (state->period < MAX_PERIOD_NS)
+		return -EINVAL;
+
+	/* (10^9 * 255) / (25000 * Freq_reg) = Period_ns */
+	freq_reg = (unsigned char)(PERIOD_NS_CONST / state->period);
+	data->hwmon_cmd0_buf[HWMON_PWM_FREQ_IDX(pwm->hwpwm)] = freq_reg;
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_HWMON_MOD,
+				   REQUEST_HWMON_CMD0_OFFSET, REQUEST_HWMON_CMD0_LEN,
+				   data->hwmon_cmd0_buf);
+	if (ret) {
+		pr_err("%s: Failed to set hwmon device!", __func__);
+		return -EIO;
+	}
+
+	/* Duty = duty * 0xFF */
+	duty = (unsigned char)(state->duty_cycle * 0xFF / state->period);
+	data->pwm_cmd1_buf[PWM_MAL_VAL(pwm->hwpwm)] = duty;
+	if (state->enabled)
+		data->pwm_cmd1_buf[PWM_MAL_EN(pwm->hwpwm / 8)] |= BIT(pwm->hwpwm  % 8);
+	else
+		data->pwm_cmd1_buf[PWM_MAL_EN(pwm->hwpwm / 8)] &= ~BIT(pwm->hwpwm  % 8);
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_PWM_MOD,
+				   REQUEST_PWM_CMD1_OFFSET, REQUEST_PWM_CMD1_LEN,
+				   data->pwm_cmd1_buf);
+	if (ret) {
+		pr_err("%s: Failed to set pwm device!", __func__);
+		return -EIO;
+	}
+
+
+	return 0;
+}
+
+static const struct pwm_ops nct6694_pwm_ops = {
+	.request = nct6694_pwm_request,
+	.apply = nct6694_pwm_apply,
+	.get_state = nct6694_pwm_get_state,
+};
+
+static int nct6694_pwm_init(struct nct6694_pwm_data *data)
+{
+	struct nct6694 *nct6694 = data->nct6694;
+	int ret;
+
+	ret = nct6694_getusb(nct6694, REQUEST_HWMON_MOD, REQUEST_HWMON_CMD0_OFFSET,
+			     REQUEST_HWMON_CMD0_LEN, 0, REQUEST_HWMON_CMD0_LEN,
+			     data->hwmon_cmd0_buf);
+	if (ret) {
+		pr_err("%s: Failed to get HWMON registers!", __func__);
+		goto err;
+	}
+	ret = nct6694_getusb(nct6694, REQUEST_PWM_MOD, REQUEST_PWM_CMD0_OFFSET,
+			     REQUEST_PWM_CMD0_LEN, 0, REQUEST_PWM_CMD0_LEN,
+			     data->pwm_cmd0_buf);
+	if (ret) {
+		pr_err("%s: Failed to get PWM registers!", __func__);
+		goto err;
+	}
+	ret = nct6694_getusb(nct6694, REQUEST_PWM_MOD, REQUEST_PWM_CMD1_OFFSET,
+				      REQUEST_PWM_CMD1_LEN, 0, REQUEST_PWM_CMD1_LEN,
+				      data->pwm_cmd1_buf);
+	if (ret) {
+		pr_err("%s: Failed to get PWM registers!", __func__);
+		goto err;
+	}
+
+err:
+	return ret;
+}
+
+static int nct6694_pwm_probe(struct platform_device *pdev)
+{
+	struct nct6694_pwm_data *data;
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+	int ret;
+
+	data = devm_kzalloc(&pdev->dev, sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->nct6694 = nct6694;
+	data->chip.dev = &pdev->dev;
+	data->chip.npwm = NR_PWM;
+	data->chip.ops = &nct6694_pwm_ops;
+
+	ret = nct6694_pwm_init(data);
+	if (ret)
+		return -EIO;
+
+	/* Register pwm device to PWM framework */
+	ret = devm_pwmchip_add(&pdev->dev, &data->chip);
+	if (ret) {
+		dev_err(&pdev->dev, "Failed to register pwm device!");
+		return ret;
+	}
+
+	dev_info(&pdev->dev, "Probe device: %s", pdev->name);
+
+	return 0;
+}
+
+static int nct6694_pwm_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+static struct platform_driver nct6694_pwm_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_pwm_probe,
+	.remove		= nct6694_pwm_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_pwm_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_pwm_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_pwm_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-pwm driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");
+

--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -404,6 +404,12 @@ config RTC_DRV_NCT3018Y
 	   This driver can also be built as a module, if so, the module will be
 	   called "rtc-nct3018y".
 
+config RTC_DRV_NCT6694
+	tristate "Nuvoton NCT6694 RTC support"
+	depends on MFD_NCT6694
+	help
+	  Say Y here to support Nuvoton NCT6694 RTC.
+
 config RTC_DRV_RK808
 	tristate "Rockchip RK805/RK808/RK809/RK817/RK818 RTC"
 	depends on MFD_RK808

--- a/drivers/rtc/Makefile
+++ b/drivers/rtc/Makefile
@@ -113,6 +113,7 @@ obj-$(CONFIG_RTC_DRV_MXC)	+= rtc-mxc.o
 obj-$(CONFIG_RTC_DRV_MXC_V2)	+= rtc-mxc_v2.o
 obj-$(CONFIG_RTC_DRV_GAMECUBE)	+= rtc-gamecube.o
 obj-$(CONFIG_RTC_DRV_NCT3018Y)	+= rtc-nct3018y.o
+obj-$(CONFIG_RTC_DRV_NCT6694)	+= rtc-nct6694.o
 obj-$(CONFIG_RTC_DRV_NTXEC)	+= rtc-ntxec.o
 obj-$(CONFIG_RTC_DRV_OMAP)	+= rtc-omap.o
 obj-$(CONFIG_RTC_DRV_OPAL)	+= rtc-opal.o

--- a/drivers/rtc/rtc-nct6694.c
+++ b/drivers/rtc/rtc-nct6694.c
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 RTC driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/rtc.h>
+#include <linux/bcd.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define DRVNAME "nct6694-rtc"
+
+
+/* Host interface */
+#define REQUEST_RTC_MOD		0x08
+
+/* Message Channel */
+/* Command 00h */
+#define REQUEST_RTC_CMD0_LEN	0x07
+#define REQUEST_RTC_CMD0_OFFSET	0x0000	/* OFFSET = SEL|CMD */
+#define RTC_SEC_IDX		0x00
+#define RTC_MIN_IDX		0x01
+#define RTC_HOUR_IDX		0x02
+#define RTC_WEEK_IDX		0x03
+#define RTC_DAY_IDX		0x04
+#define RTC_MONTH_IDX		0x05
+#define RTC_YEAR_IDX		0x06
+/* Command 01h */
+#define REQUEST_RTC_CMD1_LEN	0x05
+#define REQUEST_RTC_CMD1_OFFSET	0x0001	/* OFFSET = SEL|CMD */
+#define RTC_ALRM_EN_IDX		0x03
+#define RTC_ALRM_PEND_IDX	0x04
+/* Command 02h */
+#define REQUEST_RTC_CMD2_LEN	0x02
+#define REQUEST_RTC_CMD2_OFFSET	0x0002	/* OFFSET = SEL|CMD */
+#define RTC_IRQ_EN_IDX		0x00
+#define RTC_IRQ_PEND_IDX	0x01
+
+#define RTC_IRQ_EN		(BIT(0) | BIT(5))
+#define RTC_IRQ_INT_EN		BIT(0)	/* Transmit a USB INT-in when RTC alarm */
+#define RTC_IRQ_GPO_EN		BIT(5)	/* Trigger a GPO Low Pulse when RTC alarm */
+#define RTC_IRQ_STS		BIT(0)	/* Write 1 clear IRQ status */
+
+struct nct6694_rtc_data {
+	struct nct6694 *nct6694;
+	struct rtc_device *rtc;
+
+};
+
+static int nct6694_rtc_read_time(struct device *dev, struct rtc_time *tm)
+{
+	struct nct6694_rtc_data *data = dev_get_drvdata(dev);
+	unsigned char buf[REQUEST_RTC_CMD0_LEN];
+	int ret;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_RTC_MOD,
+			     REQUEST_RTC_CMD0_OFFSET, REQUEST_RTC_CMD0_LEN,
+			     0, REQUEST_RTC_CMD0_LEN, buf);
+	if (ret) {
+		pr_err("%s: Failed to get rtc device!", __func__);
+		return -EIO;
+	}
+
+	tm->tm_sec = bcd2bin(buf[RTC_SEC_IDX]);		/* tm_sec expect 0 ~ 59 */
+	tm->tm_min = bcd2bin(buf[RTC_MIN_IDX]);		/* tm_min expect 0 ~ 59 */
+	tm->tm_hour = bcd2bin(buf[RTC_HOUR_IDX]);	/* tm_hour expect 0 ~ 23 */
+	tm->tm_wday = bcd2bin(buf[RTC_WEEK_IDX]);	/* tm_wday expect 0 ~ 6 */
+	tm->tm_mday = bcd2bin(buf[RTC_DAY_IDX]);	/* tm_mday expect 1 ~ 31 */
+	tm->tm_mon = bcd2bin(buf[RTC_MONTH_IDX]) - 1;	/* tm_month expect 0 ~ 11 */
+	tm->tm_year = bcd2bin(buf[RTC_YEAR_IDX]) + 100;	/* tm_year expect since 1900 */
+
+	return ret;
+}
+
+static int nct6694_rtc_set_time(struct device *dev, struct rtc_time *tm)
+{
+	struct nct6694_rtc_data *data = dev_get_drvdata(dev);
+	unsigned char buf[REQUEST_RTC_CMD0_LEN];
+	int ret;
+
+	buf[RTC_SEC_IDX] = bin2bcd(tm->tm_sec);
+	buf[RTC_MIN_IDX] = bin2bcd(tm->tm_min);
+	buf[RTC_HOUR_IDX] = bin2bcd(tm->tm_hour);
+	buf[RTC_WEEK_IDX] = bin2bcd(tm->tm_wday);
+	buf[RTC_DAY_IDX] = bin2bcd(tm->tm_mday);
+	buf[RTC_MONTH_IDX] = bin2bcd(tm->tm_mon + 1);
+	buf[RTC_YEAR_IDX] = bin2bcd(tm->tm_year - 100);
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_RTC_MOD,
+				   REQUEST_RTC_CMD0_OFFSET, REQUEST_RTC_CMD0_LEN,
+				   buf);
+	if (ret) {
+		pr_err("%s: Failed to set rtc device!", __func__);
+		return -EIO;
+	}
+
+	return ret;
+}
+
+static int nct6694_rtc_read_alarm(struct device *dev, struct rtc_wkalrm *alrm)
+{
+	struct nct6694_rtc_data *data = dev_get_drvdata(dev);
+	unsigned char buf[REQUEST_RTC_CMD1_LEN];
+	int ret;
+
+	ret = nct6694_getusb(data->nct6694, REQUEST_RTC_MOD,
+			     REQUEST_RTC_CMD1_OFFSET, REQUEST_RTC_CMD1_LEN,
+			     0, REQUEST_RTC_CMD1_LEN, buf);
+	if (ret) {
+		pr_err("%s: Failed to get rtc device!", __func__);
+		return -EIO;
+	}
+
+	alrm->time.tm_sec = bcd2bin(buf[RTC_SEC_IDX]);
+	alrm->time.tm_min = bcd2bin(buf[RTC_MIN_IDX]);
+	alrm->time.tm_hour = bcd2bin(buf[RTC_HOUR_IDX]);
+
+	alrm->enabled = buf[RTC_ALRM_EN_IDX];
+	alrm->pending = buf[RTC_ALRM_PEND_IDX];
+
+	return ret;
+}
+
+static int nct6694_rtc_set_alarm(struct device *dev, struct rtc_wkalrm *alrm)
+{
+	struct nct6694_rtc_data *data = dev_get_drvdata(dev);
+	unsigned char buf[REQUEST_RTC_CMD1_LEN];
+	int ret;
+
+	buf[RTC_SEC_IDX] = bin2bcd(alrm->time.tm_sec);
+	buf[RTC_MIN_IDX] = bin2bcd(alrm->time.tm_min);
+	buf[RTC_HOUR_IDX] = bin2bcd(alrm->time.tm_hour);
+	buf[RTC_ALRM_EN_IDX] = alrm->enabled ? RTC_IRQ_EN : 0;
+	buf[RTC_ALRM_PEND_IDX] = 0;
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_RTC_MOD,
+				   REQUEST_RTC_CMD1_OFFSET, REQUEST_RTC_CMD1_LEN,
+				   buf);
+	if (ret) {
+		pr_err("%s: Failed to set rtc device!: %d", __func__, ret);
+		return -EIO;
+	}
+
+	return ret;
+}
+
+static int nct6694_rtc_alarm_irq_enable(struct device *dev, unsigned int enabled)
+{
+	struct nct6694_rtc_data *data = dev_get_drvdata(dev);
+	unsigned char buf[REQUEST_RTC_CMD2_LEN] = {0};
+	int ret;
+
+	if (enabled)
+		buf[RTC_IRQ_EN_IDX] |= RTC_IRQ_EN;
+	else
+		buf[RTC_IRQ_EN_IDX] &= ~RTC_IRQ_EN;
+
+	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_RTC_MOD,
+				   REQUEST_RTC_CMD2_OFFSET, REQUEST_RTC_CMD2_LEN,
+				   buf);
+	if (ret) {
+		pr_err("%s: Failed to set rtc device!", __func__);
+		return -EIO;
+	}
+
+	return ret;
+}
+
+static const struct rtc_class_ops nct6694_rtc_ops = {
+	.read_time = nct6694_rtc_read_time,
+	.set_time = nct6694_rtc_set_time,
+	.read_alarm = nct6694_rtc_read_alarm,
+	.set_alarm = nct6694_rtc_set_alarm,
+	.alarm_irq_enable = nct6694_rtc_alarm_irq_enable,
+};
+
+void nct6694_rtc_alarm(struct nct6694 *nct6694)
+{
+	unsigned char buf[REQUEST_RTC_CMD2_LEN] = {0};
+
+	pr_info("%s: Got RTC alarm!", __func__);
+	buf[RTC_IRQ_EN_IDX] = RTC_IRQ_EN;
+	buf[RTC_IRQ_PEND_IDX] = RTC_IRQ_STS;
+	nct6694_setusb_async(nct6694, REQUEST_RTC_MOD, REQUEST_RTC_CMD2_OFFSET,
+			     REQUEST_RTC_CMD2_LEN, buf);
+}
+
+static int nct6694_rtc_probe(struct platform_device *pdev)
+{
+	struct nct6694_rtc_data *data;
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+	int ret;
+
+	nct6694->rtc_handler = nct6694_rtc_alarm;
+
+	data = devm_kzalloc(&pdev->dev, sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->rtc = devm_rtc_allocate_device(&pdev->dev);
+	if (IS_ERR((data->rtc)))
+		return PTR_ERR(data->rtc);
+
+	data->nct6694 = nct6694;
+	data->rtc->ops = &nct6694_rtc_ops;
+	data->rtc->range_min = RTC_TIMESTAMP_BEGIN_2000;
+	data->rtc->range_max = RTC_TIMESTAMP_END_2099;
+
+	device_set_wakeup_capable(&pdev->dev, 1);
+
+	platform_set_drvdata(pdev, data);
+
+	/* Register rtc device to RTC framework */
+	ret = devm_rtc_register_device(data->rtc);
+	if (ret) {
+		dev_err(&pdev->dev, "Failed to register rtc device!");
+		return ret;
+	}
+
+	dev_info(&pdev->dev, "Probe device: %s", pdev->name);
+
+	return 0;
+}
+
+static int nct6694_rtc_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+static struct platform_driver nct6694_rtc_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_rtc_probe,
+	.remove		= nct6694_rtc_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_rtc_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_rtc_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_rtc_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-rtc driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");
+

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -628,6 +628,13 @@ config NPCM7XX_WATCHDOG
 	  This watchdog is used to reset the system and thus cannot be
 	  compiled as a module.
 
+config NCT6694_WATCHDOG
+	tristate "Nuvoton NCT6694 watchdog support"
+	depends on MFD_NCT6694
+	select WATCHDOG_CORE
+	help
+	  Say Y here to support Nuvoton NCT6694 watchdog.
+
 config TWL4030_WATCHDOG
 	tristate "TWL4030 Watchdog"
 	depends on TWL4030_CORE

--- a/drivers/watchdog/Makefile
+++ b/drivers/watchdog/Makefile
@@ -62,6 +62,7 @@ obj-$(CONFIG_ORION_WATCHDOG) += orion_wdt.o
 obj-$(CONFIG_SUNXI_WATCHDOG) += sunxi_wdt.o
 obj-$(CONFIG_RN5T618_WATCHDOG) += rn5t618_wdt.o
 obj-$(CONFIG_NPCM7XX_WATCHDOG) += npcm_wdt.o
+obj-$(CONFIG_NCT6694_WATCHDOG) += nct6694_wdt.o
 obj-$(CONFIG_STMP3XXX_RTC_WATCHDOG) += stmp3xxx_rtc_wdt.o
 obj-$(CONFIG_TS4800_WATCHDOG) += ts4800_wdt.o
 obj-$(CONFIG_TS72XX_WATCHDOG) += ts72xx_wdt.o

--- a/drivers/watchdog/nct6694_wdt.c
+++ b/drivers/watchdog/nct6694_wdt.c
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Nuvoton NCT6694 WDT driver based on USB interface.
+ *
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#include <linux/watchdog.h>
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/mfd/nct6694.h>
+
+#define DRVNAME "nct6694-wdt"
+
+#define NR_WDT	2
+#define WATCHDOG_TIMEOUT	10
+#define WATCHDOG_PRETIMEOUT	0
+
+/* Host interface */
+#define REQUEST_WDT_MOD		0x07
+
+/* Message Channel*/
+/* Command 00h */
+#define REQUEST_WDT_CMD0_LEN	0x0F
+#define REQUEST_WDT_CMD0_OFFSET(idx) (idx ? 0x0100 : 0x0000)	/* OFFSET = SEL|CMD */
+#define WDT_PRETIMEOUT_IDX	0x00
+#define WDT_PRETIMEOUT_LEN	0x04	/* PRETIMEOUT(3byte) | ACT(1byte) */
+#define WDT_IMEOUT_IDX		0x04
+#define WDT_TIMEOUT_LEN		0x04	/* TIMEOUT(3byte) | ACT(1byte) */
+#define WDT_COUNTDOWN_IDX	0x0C
+#define WDT_COUNTDOWN_LEN	0x03
+
+#define WDT_PRETIMEOUT_ACT	BIT(1)
+#define WDT_TIMEOUT_ACT		BIT(1)
+
+
+/* Command 01h */
+#define REQUEST_WDT_CMD1_LEN	0x04
+#define REQUEST_WDT_CMD1_OFFSET(idx) (idx ? 0x0101 : 0x0001)	/* OFFSET = SEL|CMD */
+#define WDT_CMD_IDX		0x00
+#define WDT_CMD_LEN		0x04
+
+#define SET_BUF32(buf, u32_val) { \
+	*(((u8 *)buf)+0) = u32_val & 0xFF; \
+	*(((u8 *)buf)+1) = (u32_val>>8) & 0xFF; \
+	*(((u8 *)buf)+2) = (u32_val>>16) & 0xFF; \
+	*(((u8 *)buf)+3) = (u32_val>>24) & 0xFF; \
+}
+
+static unsigned int timeout;
+module_param(timeout, int, 0);
+MODULE_PARM_DESC(timeout, "Watchdog timeout in seconds");
+
+static unsigned int pretimeout;
+module_param(pretimeout, int, 0);
+MODULE_PARM_DESC(pretimeout, "Watchdog pre-timeout in seconds");
+
+static bool nowayout = WATCHDOG_NOWAYOUT;
+module_param(nowayout, bool, 0);
+MODULE_PARM_DESC(nowayout, "Watchdog cannot be stopped once started (default="
+			   __MODULE_STRING(WATCHDOG_NOWAYOUT) ")");
+
+
+struct nct6694_wdt_data {
+	struct nct6694 *nct6694;
+	struct nct6694_wdt_dev *wdevs;
+	int nr_wdev;
+};
+
+struct nct6694_wdt_dev {
+	struct watchdog_device wdev;
+	struct nct6694_wdt_data *data;
+	unsigned int wdev_idx;
+};
+
+
+static int nct6694_wdt_start(struct watchdog_device *wdev)
+{
+	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+
+	pr_info("%s: WDT(%d) Start\n", __func__, wdt->wdev_idx);
+
+	return 0;
+}
+
+static int nct6694_wdt_stop(struct watchdog_device *wdev)
+{
+	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = wdt->data->nct6694;
+	unsigned char buf[REQUEST_WDT_CMD1_LEN] = {'W', 'D', 'T', 'C'};
+	int ret;
+
+	pr_info("%s: WDT(%d) Close\n", __func__, wdt->wdev_idx);
+	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
+				   REQUEST_WDT_CMD1_OFFSET(wdt->wdev_idx),
+				   REQUEST_WDT_CMD1_LEN, buf);
+	if (ret)
+		pr_err("%s: Failed to start WDT device!\n", __func__);
+
+	return ret;
+}
+
+static int nct6694_wdt_ping(struct watchdog_device *wdev)
+{
+	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = wdt->data->nct6694;
+	unsigned char buf[REQUEST_WDT_CMD1_LEN] = {'W', 'D', 'T', 'S'};
+	int ret;
+
+	pr_debug("%s: WDT(%d) Ping\n", __func__, wdt->wdev_idx);
+	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
+				   REQUEST_WDT_CMD1_OFFSET(wdt->wdev_idx),
+				   REQUEST_WDT_CMD1_LEN, buf);
+	if (ret)
+		pr_err("%s: Failed to Ping WDT device!\n", __func__);
+
+	return 0;
+}
+
+static int nct6694_wdt_set_timeout(struct watchdog_device *wdev,
+				   unsigned int timeout)
+{
+	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = wdt->data->nct6694;
+	unsigned int timeout_fmt, pretimeout_fmt;
+	unsigned char buf[REQUEST_WDT_CMD0_LEN];
+	int ret;
+
+	if (timeout < wdev->pretimeout) {
+		pr_err("%s: 'timeout' must be greater than 'pre timeout'!", __func__);
+		return -EINVAL;
+	}
+
+	timeout_fmt = timeout * 1000 | (WDT_TIMEOUT_ACT << 24);
+	pretimeout_fmt = wdev->pretimeout * 1000 | (WDT_PRETIMEOUT_ACT << 24);
+	SET_BUF32(&buf[WDT_IMEOUT_IDX], le32_to_cpu(timeout_fmt));
+	SET_BUF32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
+
+	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
+				   REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
+				   REQUEST_WDT_CMD0_LEN, buf);
+	if (ret) {
+		pr_err("%s: Don't write the setup command in Start stage!\n", __func__);
+		return ret;
+	}
+	wdev->timeout = timeout;
+
+	return 0;
+}
+
+static int nct6694_wdt_set_pretimeout(struct watchdog_device *wdev,
+				      unsigned int pretimeout)
+{
+	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = wdt->data->nct6694;
+	unsigned int timeout_fmt, pretimeout_fmt;
+	unsigned char buf[REQUEST_WDT_CMD0_LEN];
+	int ret;
+
+	if (pretimeout > wdev->timeout) {
+		pr_err("%s: 'pre timeout' must be less than 'timeout'!", __func__);
+		return -EINVAL;
+	}
+	timeout_fmt = wdev->timeout * 1000 | (WDT_TIMEOUT_ACT << 24);
+	pretimeout_fmt = pretimeout * 1000 | (WDT_PRETIMEOUT_ACT << 24);
+	SET_BUF32(&buf[WDT_IMEOUT_IDX], le32_to_cpu(timeout_fmt));
+	SET_BUF32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
+
+	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
+					    REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
+					    REQUEST_WDT_CMD0_LEN, buf);
+	if (ret) {
+		pr_info("%s: Don't write the setup command in Start stage!\n", __func__);
+		return ret;
+	}
+	wdev->pretimeout = pretimeout;
+	return 0;
+}
+
+static unsigned int nct6694_wdt_get_time(struct watchdog_device *wdev)
+{
+	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = wdt->data->nct6694;
+	unsigned char buf[WDT_COUNTDOWN_LEN];
+	unsigned int timeleft_ms;
+	int ret;
+
+	ret = nct6694_getusb(nct6694, REQUEST_WDT_MOD,
+				      REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
+				      REQUEST_WDT_CMD0_LEN, WDT_COUNTDOWN_IDX,
+				      WDT_COUNTDOWN_LEN, buf);
+	if (ret)
+		pr_info("%s: Failed to get WDT device!\n", __func__);
+
+	timeleft_ms = ((buf[2] << 16) | (buf[1] << 8) | buf[0]) & 0xFFFFFF;
+
+	return timeleft_ms/1000;
+}
+
+static int nct6694_wdt_setup(struct watchdog_device *wdev)
+{
+	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = wdt->data->nct6694;
+	unsigned char buf[REQUEST_WDT_CMD0_LEN] = {0};
+	unsigned int timeout_fmt, pretimeout_fmt;
+	int ret;
+
+	if (timeout)
+		wdev->timeout = timeout;
+
+	if (pretimeout) {
+		wdev->pretimeout = pretimeout;
+		pretimeout_fmt = wdev->pretimeout*1000 | (WDT_PRETIMEOUT_ACT << 24);
+	} else {
+		pretimeout_fmt = 0;
+	}
+
+	timeout_fmt = wdev->timeout*1000 | (WDT_TIMEOUT_ACT << 24);
+	SET_BUF32(&buf[WDT_IMEOUT_IDX], le32_to_cpu(timeout_fmt));
+	SET_BUF32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
+
+	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
+					    REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
+					    REQUEST_WDT_CMD0_LEN, buf);
+	if (ret)
+		return ret;
+
+	pr_info("Setting WDT(%d): timeout = %d, pretimeout = %d", wdt->wdev_idx,
+								  wdev->timeout,
+								  wdev->pretimeout);
+
+	return 0;
+}
+
+static const struct watchdog_info nct6694_wdt_info = {
+	.options = WDIOF_SETTIMEOUT		|
+			   WDIOF_KEEPALIVEPING	|
+				WDIOF_MAGICCLOSE	|
+				WDIOF_PRETIMEOUT,
+	.identity = DRVNAME,
+};
+
+static const struct watchdog_ops nct6694_wdt_ops = {
+	.owner = THIS_MODULE,
+	.start = nct6694_wdt_start,
+	.stop = nct6694_wdt_stop,
+	.ping = nct6694_wdt_ping,
+	.set_timeout = nct6694_wdt_set_timeout,
+	.set_pretimeout = nct6694_wdt_set_pretimeout,
+	.get_timeleft = nct6694_wdt_get_time,
+};
+
+#define NCT6694_WDT_DEVICE(_wdev_idx)	\
+{	\
+	.wdev = {	\
+		.info	= &nct6694_wdt_info,	\
+		.ops  = &nct6694_wdt_ops,	\
+		.timeout = WATCHDOG_TIMEOUT,	\
+		.pretimeout = WATCHDOG_PRETIMEOUT,	\
+		.min_timeout = 1,	\
+		.max_timeout = 255,	\
+	},	\
+	.wdev_idx = _wdev_idx,	\
+}
+
+static struct nct6694_wdt_dev nct6694_wdt_dev[] = {
+	NCT6694_WDT_DEVICE(0),
+	NCT6694_WDT_DEVICE(1),
+};
+
+
+static int nct6694_wdt_probe(struct platform_device *pdev)
+{
+	struct nct6694_wdt_data *data;
+	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
+	int i, ret;
+
+	data = kzalloc(sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->nct6694 = nct6694;
+	data->wdevs = nct6694_wdt_dev;
+	data->nr_wdev = ARRAY_SIZE(nct6694_wdt_dev);
+	platform_set_drvdata(pdev, data);
+
+	/* Register each wdt device to WDT framework */
+	for (i = 0; i < data->nr_wdev; i++) {
+		struct nct6694_wdt_dev *wdev = &data->wdevs[i];
+
+		wdev->data = data;
+		watchdog_set_drvdata(&data->wdevs[i].wdev, &data->wdevs[i]);
+		watchdog_init_timeout(&data->wdevs[i].wdev, timeout, &pdev->dev);
+		watchdog_set_nowayout(&data->wdevs[i].wdev, nowayout);
+		watchdog_stop_on_reboot(&data->wdevs[i].wdev);
+
+		ret = watchdog_register_device(&data->wdevs[i].wdev);
+		if (ret) {
+			dev_err(&pdev->dev, "Failed to register watchdog device: %d", ret);
+			return ret;
+		}
+
+		ret = nct6694_wdt_setup(&data->wdevs[i].wdev);
+		if (ret) {
+			dev_err(&pdev->dev, "Failed to setup WDT device!");
+			return ret;
+		}
+	}
+
+	dev_info(&pdev->dev, "Probe device :%s", pdev->name);
+
+	return 0;
+}
+
+static int nct6694_wdt_remove(struct platform_device *pdev)
+{
+	struct nct6694_wdt_data *data = platform_get_drvdata(pdev);
+	int i;
+
+	for (i = 0; i < data->nr_wdev; i++)
+		watchdog_unregister_device(&data->wdevs[i].wdev);
+
+	kfree(data);
+	return 0;
+}
+
+static struct platform_driver nct6694_wdt_driver = {
+	.driver = {
+		.name	= DRVNAME,
+	},
+	.probe		= nct6694_wdt_probe,
+	.remove		= nct6694_wdt_remove,
+};
+
+static int __init nct6694_init(void)
+{
+	int err;
+
+	err = platform_driver_register(&nct6694_wdt_driver);
+	if (!err) {
+		pr_info(DRVNAME ": platform_driver_register\n");
+		if (err)
+			platform_driver_unregister(&nct6694_wdt_driver);
+	}
+
+	return err;
+}
+subsys_initcall(nct6694_init);
+
+static void __exit nct6694_exit(void)
+{
+	platform_driver_unregister(&nct6694_wdt_driver);
+}
+module_exit(nct6694_exit);
+
+MODULE_DESCRIPTION("USB-wdt driver for NCT6694");
+MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
+MODULE_LICENSE("GPL");
+

--- a/include/linux/mfd/nct6694.h
+++ b/include/linux/mfd/nct6694.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * Copyright (C) 2024 Nuvoton Technology Corp.
+ */
+
+#ifndef __LINUX_MFD_NCT6694_H
+#define __LINUX_MFD_NCT6694_H
+
+#define NCT6694_VENDOR_ID		0x0416
+#define NCT6694_PRODUCT_ID		0x200B
+#define INT_IN_ENDPOINT			0x81
+#define BULK_IN_ENDPOINT		0x82
+#define BULK_OUT_ENDPOINT		0x03
+#define MAX_PACKET_SZ			0x100
+
+#define CMD_PACKET_SZ			0x8
+#define HCTRL_SET			0x40
+#define HCTRL_GET			0x80
+
+#define REQUEST_MOD_IDX			0x01
+#define REQUEST_CMD_IDX			0x02
+#define REQUEST_SEL_IDX			0x03
+#define REQUEST_HCTRL_IDX		0x04
+#define REQUEST_LEN_L_IDX		0x06
+#define REQUEST_LEN_H_IDX		0x07
+
+#define RESPONSE_STS_IDX		0x01
+
+#define GPIO_IRQ_STATUS			BIT(0)
+#define CAN_IRQ_STATUS			BIT(2)
+#define RTC_IRQ_STATUS			BIT(3)
+
+#define URB_TIMEOUT			0
+
+struct nct6694 {
+	struct usb_device *udev;
+	struct urb *int_in_urb;
+	struct mutex access_lock;
+	struct workqueue_struct *async_workqueue;
+	struct work_struct async_work;
+
+	unsigned char *tx_buffer;
+	unsigned char *rx_buffer;
+	unsigned char *cmd_buffer;
+	unsigned char *int_buffer;
+	unsigned char err_status;
+
+	u8 MOD;
+	u16 OFFSET;
+	u16 LEN;
+	unsigned char *buf;
+	long timeout;
+	int maxp;	/* Bulk pipe maximum packet for each transaction*/
+
+	void (*gpio_handler)(struct nct6694 *nct6694);
+	void (*can_handler)(struct nct6694 *nct6694);
+	void (*rtc_handler)(struct nct6694 *nct6694);
+};
+
+extern int nct6694_getusb(struct nct6694 *nct6694, u8 MOD, u16 OFFSET, u16 LEN,
+			  u8 rd_idx, u8 rd_len, unsigned char *buf);
+extern int nct6694_setusb_rdata(struct nct6694 *nct6694, u8 MOD, u16 OFFSET,
+				u16 LEN, u8 rd_idx, u8 rd_len, unsigned char *buf);
+extern int nct6694_setusb_wdata(struct nct6694 *nct6694, u8 MOD, u16 OFFSET,
+				u16 LEN, unsigned char *buf);
+extern void nct6694_setusb_async(struct nct6694 *nct6694, u8 MOD, u16 OFFSET,
+				 u16 LEN, unsigned char *buf);
+
+#endif


### PR DESCRIPTION
The patch add to support for NCT6694 chip functionality using USB interface (idVendor=0416, idProduct=200b), which offers GPIO controller, I2C Adapter, Socket CANfd, WDT, IIO, HWMON, PWM, and RTC.