### PR TITLE
mfd driver expose child devices

### DIFF
--- a/drivers/iio/adc/nct6694_adc.c
+++ b/drivers/iio/adc/nct6694_adc.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Nuvoton NCT6694 IIO driver based on USB interface.
  *
@@ -21,25 +21,24 @@
 /* Report Channel */
 #define IIO_VIN_STS(x)		(0x68 + (x))
 #define IIO_TMP_STS(x)		(0x6A + (x))
-#define IIO_TMP_STS_CH(x)	(x < 10 ? x : ((x) + 6))
+#define IIO_TMP_STS_CH(x)	((x) < 10 ? x : ((x) + 6))
 
 /* Message Channel*/
 /* Command 00h */
 #define REQUEST_IIO_CMD0_LEN	0x40
-#define REQUEST_IIO_CMD0_OFFSET	0x0000	/* OFFSET = SEL|CMD */
+#define REQUEST_IIO_CMD0_OFFSET 0x0000	/* OFFSET = SEL|CMD */
 #define IIO_VIN_EN(x)		(0x00 + (x))
 #define IIO_TMP_EN(x)		(0x02 + (x))
 /* Command 02h */
 #define REQUEST_IIO_CMD2_LEN	0x90
-#define REQUEST_IIO_CMD2_OFFSET	0x0002	/* OFFSET = SEL|CMD */
+#define REQUEST_IIO_CMD2_OFFSET 0x0002	/* OFFSET = SEL|CMD */
 #define IIO_SMI_CTRL_IDX	0x00
 #define IIO_VIN_LIMIT_IDX(x)	(0x10 + ((x) * 2))
 #define IIO_TMP_LIMIT_IDX(x)	(0x30 + ((x) * 2))
 #define IIO_CMD2_HYST_MASK	0x1F
 /* Command 03h */
 #define REQUEST_IIO_CMD3_LEN	0x08
-#define REQUEST_IIO_CMD3_OFFSET	0x0003	/* OFFSET = SEL|CMD */
-
+#define REQUEST_IIO_CMD3_OFFSET 0x0003	/* OFFSET = SEL|CMD */
 
 struct nct6694_iio_data {
 	struct nct6694 *nct6694;
@@ -50,12 +49,14 @@ static const struct iio_event_spec nct6694_volt_events[] = {
 	{
 		.type = IIO_EV_TYPE_THRESH,
 		.dir = IIO_EV_DIR_RISING,
-		.mask_separate = BIT(IIO_EV_INFO_VALUE) | BIT(IIO_EV_INFO_ENABLE),
+		.mask_separate = BIT(IIO_EV_INFO_VALUE) |
+				 BIT(IIO_EV_INFO_ENABLE),
 	},
 	{
 		.type = IIO_EV_TYPE_THRESH,
 		.dir = IIO_EV_DIR_FALLING,
-		.mask_separate = BIT(IIO_EV_INFO_VALUE) | BIT(IIO_EV_INFO_ENABLE),
+		.mask_separate = BIT(IIO_EV_INFO_VALUE) |
+				 BIT(IIO_EV_INFO_ENABLE),
 	}
 };
 
@@ -63,31 +64,32 @@ static const struct iio_event_spec nct6694_temp_events[] = {
 	{
 		.type = IIO_EV_TYPE_THRESH,
 		.dir = IIO_EV_DIR_RISING,
-		.mask_separate = BIT(IIO_EV_INFO_VALUE) | BIT(IIO_EV_INFO_ENABLE),
+		.mask_separate = BIT(IIO_EV_INFO_VALUE) |
+				 BIT(IIO_EV_INFO_ENABLE),
 	}
 };
 
-#define NCT6694_VOLTAGE_CHANNEL(num, addr) { \
-	.type = IIO_VOLTAGE, \
-	.indexed = 1, \
-	.channel = num, \
-	.address = addr, \
-	.info_mask_separate = BIT(IIO_CHAN_INFO_ENABLE) | \
-			      BIT(IIO_CHAN_INFO_PROCESSED), \
-	.event_spec = nct6694_volt_events, \
-	.num_event_specs = ARRAY_SIZE(nct6694_volt_events), \
+#define NCT6694_VOLTAGE_CHANNEL(num, addr) {			\
+	.type = IIO_VOLTAGE,					\
+	.indexed = 1,						\
+	.channel = num,						\
+	.address = addr,					\
+	.info_mask_separate = BIT(IIO_CHAN_INFO_ENABLE) |	\
+			      BIT(IIO_CHAN_INFO_PROCESSED),	\
+	.event_spec = nct6694_volt_events,			\
+	.num_event_specs = ARRAY_SIZE(nct6694_volt_events),	\
 }
 
-#define NCT6694_TEMPERATURE_CHANNEL(num, addr) { \
-	.type = IIO_TEMP, \
-	.indexed = 1, \
-	.channel = num, \
-	.address = addr, \
-	.info_mask_separate = BIT(IIO_CHAN_INFO_ENABLE) | \
-			      BIT(IIO_CHAN_INFO_PROCESSED) | \
-			      BIT(IIO_CHAN_INFO_HYSTERESIS), \
-	.event_spec = nct6694_temp_events, \
-	.num_event_specs = ARRAY_SIZE(nct6694_temp_events), \
+#define NCT6694_TEMPERATURE_CHANNEL(num, addr) {		\
+	.type = IIO_TEMP,					\
+	.indexed = 1,						\
+	.channel = num,						\
+	.address = addr,					\
+	.info_mask_separate = BIT(IIO_CHAN_INFO_ENABLE) |	\
+			      BIT(IIO_CHAN_INFO_PROCESSED) |	\
+			      BIT(IIO_CHAN_INFO_HYSTERESIS),	\
+	.event_spec = nct6694_temp_events,			\
+	.num_event_specs = ARRAY_SIZE(nct6694_temp_events),	\
 }
 
 static const struct iio_chan_spec nct6694_iio_channels[] = {
@@ -145,7 +147,7 @@ static int nct6694_read_raw(struct iio_dev *indio_dev,
 	unsigned char buf[2], tmp_hyst, enable_idx;
 	int ret;
 
-	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+	if (chan->type != IIO_VOLTAGE && chan->type != IIO_TEMP)
 		return -EOPNOTSUPP;
 
 	switch (mask) {
@@ -162,27 +164,27 @@ static int nct6694_read_raw(struct iio_dev *indio_dev,
 		default:
 			return -EINVAL;
 		}
-		ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-				     REQUEST_IIO_CMD0_OFFSET,
-				     REQUEST_IIO_CMD0_LEN,
-				     enable_idx, 1, buf);
-		if (ret) {
-			pr_err("%s: Failed to get iio device!:%d", __func__, ret);
+		ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+				       REQUEST_IIO_CMD0_OFFSET,
+				       REQUEST_IIO_CMD0_LEN, enable_idx,
+				       1, buf);
+		if (ret)
 			return -EINVAL;
-		}
+
 		*val = buf[0] & BIT(chan->channel % 8) ? 1 : 0;
+
 		return IIO_VAL_INT;
 
 	case IIO_CHAN_INFO_PROCESSED:
-		ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
-				     chan->address, 2, 0, 2, buf);
-		if (ret) {
-			pr_err("%s: Failed to get iio device!\n", __func__);
+		ret = nct6694_read_msg(data->nct6694, REQUEST_RPT_MOD,
+				       chan->address, 2, 0, 2, buf);
+		if (ret)
 			return -EINVAL;
-		}
+
 		switch (chan->type) {
 		case IIO_VOLTAGE:	/* in micro Voltage */
 			*val = buf[0] * 16;
+
 			return IIO_VAL_INT;
 
 		case IIO_TEMP:	/* in milli degrees Celsius */
@@ -198,19 +200,19 @@ static int nct6694_read_raw(struct iio_dev *indio_dev,
 		}
 
 	case IIO_CHAN_INFO_HYSTERESIS:
-		ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-				     REQUEST_IIO_CMD2_OFFSET,
-				     REQUEST_IIO_CMD2_LEN,
-				     IIO_TMP_LIMIT_IDX(chan->channel),
-				     2, buf);
-		if (ret) {
-			pr_err("%s: Failed to get iio device!\n", __func__);
+		ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+				       REQUEST_IIO_CMD2_OFFSET,
+				       REQUEST_IIO_CMD2_LEN,
+				       IIO_TMP_LIMIT_IDX(chan->channel),
+				       2, buf);
+		if (ret)
 			return -EINVAL;
-		}
+
 		switch (chan->type) {
 		case IIO_TEMP:	/* in milli degrees Celsius */
 			tmp_hyst = buf[0] >> 5;
 			*val = (buf[1] - tmp_hyst) * 1000;
+
 			return IIO_VAL_INT;
 
 		default:
@@ -232,47 +234,53 @@ static int nct6694_write_raw(struct iio_dev *indio_dev,
 	unsigned char delta_hyst;
 	int ret;
 
-	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+	if (chan->type != IIO_VOLTAGE && chan->type != IIO_TEMP)
 		return -EOPNOTSUPP;
 
 	switch (mask) {
 	case IIO_CHAN_INFO_ENABLE:
 		mutex_lock(&data->iio_lock);
-		ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-				     REQUEST_IIO_CMD0_OFFSET,
-				     REQUEST_IIO_CMD0_LEN, 0,
-				     REQUEST_IIO_CMD0_LEN,
-				     enable_buf);
-		if (ret) {
-			pr_err("%s: Failed to get iio device!\n", __func__);
+		ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+				       REQUEST_IIO_CMD0_OFFSET,
+				       REQUEST_IIO_CMD0_LEN, 0,
+				       REQUEST_IIO_CMD0_LEN,
+				       enable_buf);
+		if (ret)
 			goto err;
-		}
+
 		switch (chan->type) {
 		case IIO_VOLTAGE:
-			if (val)
-				enable_buf[IIO_VIN_EN(chan->channel / 8)] |= BIT(chan->channel % 8);
-			else
-				enable_buf[IIO_VIN_EN(chan->channel / 8)] &= ~BIT(chan->channel % 8);
+			if (val) {
+				enable_buf[IIO_VIN_EN(chan->channel / 8)] |=
+				BIT(chan->channel % 8);
+			} else {
+				enable_buf[IIO_VIN_EN(chan->channel / 8)] &=
+				~BIT(chan->channel % 8);
+			}
+
 			break;
 
 		case IIO_TEMP:
-			if (val)
-				enable_buf[IIO_TMP_EN(chan->channel / 8)] |= BIT(chan->channel % 8);
-			else
-				enable_buf[IIO_TMP_EN(chan->channel / 8)] &= ~BIT(chan->channel % 8);
+			if (val) {
+				enable_buf[IIO_TMP_EN(chan->channel / 8)] |=
+				BIT(chan->channel % 8);
+			} else {
+				enable_buf[IIO_TMP_EN(chan->channel / 8)] &=
+				~BIT(chan->channel % 8);
+			}
+
 			break;
 
 		default:
 			ret = -EINVAL;
 			goto err;
 		}
-		ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
-					   REQUEST_IIO_CMD0_OFFSET,
-					   REQUEST_IIO_CMD0_LEN, enable_buf);
-		if (ret) {
-			pr_err("%s: Failed to set iio device!\n", __func__);
+
+		ret = nct6694_write_msg(data->nct6694, REQUEST_IIO_MOD,
+					REQUEST_IIO_CMD0_OFFSET,
+					REQUEST_IIO_CMD0_LEN, enable_buf);
+		if (ret)
 			goto err;
-		}
 
 		break;
 
@@ -280,18 +288,17 @@ static int nct6694_write_raw(struct iio_dev *indio_dev,
 		switch (chan->type) {
 		case IIO_TEMP:
 			mutex_lock(&data->iio_lock);
-			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-					     REQUEST_IIO_CMD2_OFFSET,
-					     REQUEST_IIO_CMD2_LEN, 0,
-					     REQUEST_IIO_CMD2_LEN, buf);
-			if (ret) {
-				pr_err("Failed to get iio registers!");
+			ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+					       REQUEST_IIO_CMD2_OFFSET,
+					       REQUEST_IIO_CMD2_LEN, 0,
+					       REQUEST_IIO_CMD2_LEN, buf);
+			if (ret)
 				goto err;
-			}
 
-			delta_hyst = buf[IIO_TMP_LIMIT_IDX(chan->channel) + 1] - (u8) val;
+			delta_hyst = buf[IIO_TMP_LIMIT_IDX(chan->channel) + 1] - (u8)val;
 			if (delta_hyst > 7) {
-				pr_err("%s: The Hysteresis value must be less than 7!", __func__);
+				pr_err("%s: The Hysteresis value must be less than 7!\n",
+				       __func__);
 				ret = -EINVAL;
 				goto err;
 			}
@@ -304,13 +311,11 @@ static int nct6694_write_raw(struct iio_dev *indio_dev,
 			ret = -EINVAL;
 			goto err;
 		}
-		ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
-					   REQUEST_IIO_CMD2_OFFSET,
-					   REQUEST_IIO_CMD2_LEN, buf);
-		if (ret) {
-			pr_err("%s: Failed to set iio device!\n", __func__);
+		ret = nct6694_write_msg(data->nct6694, REQUEST_IIO_MOD,
+					REQUEST_IIO_CMD2_OFFSET,
+					REQUEST_IIO_CMD2_LEN, buf);
+		if (ret)
 			goto err;
-		}
 
 		break;
 
@@ -333,32 +338,30 @@ static int nct6694_read_event_config(struct iio_dev *indio_dev,
 	unsigned char buf;
 	int ret;
 
-	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+	if (chan->type != IIO_VOLTAGE && chan->type != IIO_TEMP)
 		return -EOPNOTSUPP;
 
 	switch (dir) {
 	case IIO_EV_DIR_RISING:
 		switch (chan->type) {
 		case IIO_VOLTAGE:
-			ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
-					     IIO_VIN_STS(chan->channel / 8),
-					     1, 0, 1, &buf);
-			if (ret) {
-				pr_err("%s: Failed to get iio device!\n", __func__);
+			ret = nct6694_read_msg(data->nct6694, REQUEST_RPT_MOD,
+					       IIO_VIN_STS(chan->channel / 8),
+					       1, 0, 1, &buf);
+			if (ret)
 				return -EINVAL;
-			}
+
 			return !!(buf & BIT(chan->channel % 8));
 
 		case IIO_TEMP:
 			u8 ch = IIO_TMP_STS_CH(chan->channel);
 
-			ret = nct6694_getusb(data->nct6694, REQUEST_RPT_MOD,
-					     IIO_TMP_STS(ch / 8),
-					     1, 0, 1, &buf);
-			if (ret) {
-				pr_err("%s: Failed to get iio device!\n", __func__);
+			ret = nct6694_read_msg(data->nct6694, REQUEST_RPT_MOD,
+					       IIO_TMP_STS(ch / 8),
+					       1, 0, 1, &buf);
+			if (ret)
 				return -EINVAL;
-			}
+
 			return !!(buf & BIT(ch % 8));
 
 		default:
@@ -383,36 +386,32 @@ static int nct6694_read_event_value(struct iio_dev *indio_dev,
 	unsigned char buf[2];
 	int ret;
 
-	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+	if (chan->type != IIO_VOLTAGE && chan->type != IIO_TEMP)
 		return -EOPNOTSUPP;
 
 	switch (dir) {
 	case IIO_EV_DIR_RISING:
 		switch (chan->type) {
 		case IIO_VOLTAGE:
-			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-					     REQUEST_IIO_CMD2_OFFSET,
-					     REQUEST_IIO_CMD2_LEN,
-					     IIO_VIN_LIMIT_IDX(chan->channel),
-					     2, buf);
-			if (ret) {
-				pr_err("%s: Failed to get iio device!\n", __func__);
+			ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+					       REQUEST_IIO_CMD2_OFFSET,
+					       REQUEST_IIO_CMD2_LEN,
+					       IIO_VIN_LIMIT_IDX(chan->channel),
+					       2, buf);
+			if (ret)
 				return -EINVAL;
-			}
 
 			*val = buf[0] * 16;
 			return IIO_VAL_INT;
 
 		case IIO_TEMP:
-			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-					     REQUEST_IIO_CMD2_OFFSET,
-					     REQUEST_IIO_CMD2_LEN,
-					     IIO_TMP_LIMIT_IDX(chan->channel),
-					     2, buf);
-			if (ret) {
-				pr_err("%s: Failed to get iio device!\n", __func__);
+			ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+					       REQUEST_IIO_CMD2_OFFSET,
+					       REQUEST_IIO_CMD2_LEN,
+					       IIO_TMP_LIMIT_IDX(chan->channel),
+					       2, buf);
+			if (ret)
 				return -EINVAL;
-			}
 
 			*val = (signed char)buf[1] * 1000;
 			return IIO_VAL_INT;
@@ -424,15 +423,13 @@ static int nct6694_read_event_value(struct iio_dev *indio_dev,
 	case IIO_EV_DIR_FALLING:
 		switch (chan->type) {
 		case IIO_VOLTAGE:
-			ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-					     REQUEST_IIO_CMD2_OFFSET,
-					     REQUEST_IIO_CMD2_LEN,
-					     IIO_VIN_LIMIT_IDX(chan->channel),
-					     2, buf);
-			if (ret) {
-				pr_err("%s: Failed to get iio device!\n", __func__);
+			ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+					       REQUEST_IIO_CMD2_OFFSET,
+					       REQUEST_IIO_CMD2_LEN,
+					       IIO_VIN_LIMIT_IDX(chan->channel),
+					       2, buf);
+			if (ret)
 				return -EINVAL;
-			}
 
 			*val = buf[1] * 16;
 			return IIO_VAL_INT;
@@ -457,28 +454,26 @@ static int nct6694_write_event_value(struct iio_dev *indio_dev,
 	unsigned char buf[REQUEST_IIO_CMD2_LEN] = {0};
 	int ret;
 
-	if ((chan->type != IIO_VOLTAGE) && (chan->type != IIO_TEMP))
+	if (chan->type != IIO_VOLTAGE && chan->type != IIO_TEMP)
 		return -EOPNOTSUPP;
 
 	mutex_lock(&data->iio_lock);
-	ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-			     REQUEST_IIO_CMD2_OFFSET,
-			     REQUEST_IIO_CMD2_LEN, 0,
-			     REQUEST_IIO_CMD2_LEN, buf);
-	if (ret) {
-		pr_err("Failed to get iio registers!");
+	ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+			       REQUEST_IIO_CMD2_OFFSET,
+			       REQUEST_IIO_CMD2_LEN, 0,
+			       REQUEST_IIO_CMD2_LEN, buf);
+	if (ret)
 		goto err;
-	}
 
 	switch (dir) {
 	case IIO_EV_DIR_RISING:
 		switch (chan->type) {
 		case IIO_VOLTAGE:
-			buf[IIO_VIN_LIMIT_IDX(chan->channel)] = (u8) val;
+			buf[IIO_VIN_LIMIT_IDX(chan->channel)] = (u8)val;
 			break;
 
 		case IIO_TEMP:
-			buf[IIO_TMP_LIMIT_IDX(chan->channel) + 1] = (s8) val;
+			buf[IIO_TMP_LIMIT_IDX(chan->channel) + 1] = (s8)val;
 			break;
 
 		default:
@@ -490,7 +485,7 @@ static int nct6694_write_event_value(struct iio_dev *indio_dev,
 	case IIO_EV_DIR_FALLING:
 		switch (chan->type) {
 		case IIO_VOLTAGE:
-			buf[IIO_VIN_LIMIT_IDX(chan->channel) + 1] = (u8) val;
+			buf[IIO_VIN_LIMIT_IDX(chan->channel) + 1] = (u8)val;
 			break;
 
 		default:
@@ -504,13 +499,11 @@ static int nct6694_write_event_value(struct iio_dev *indio_dev,
 		goto err;
 	}
 
-	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
-				   REQUEST_IIO_CMD2_OFFSET,
-				   REQUEST_IIO_CMD2_LEN, buf);
-	if (ret) {
-		pr_err("%s: Failed to set usb device!", __func__);
+	ret = nct6694_write_msg(data->nct6694, REQUEST_IIO_MOD,
+				REQUEST_IIO_CMD2_OFFSET,
+				REQUEST_IIO_CMD2_LEN, buf);
+	if (ret)
 		goto err;
-	}
 
 err:
 	mutex_unlock(&data->iio_lock);
@@ -532,23 +525,19 @@ static int nct6694_iio_init(struct nct6694_iio_data *data)
 
 	/* Set VIN & TMP Real Time alarm mode */
 	mutex_lock(&data->iio_lock);
-	ret = nct6694_getusb(data->nct6694, REQUEST_IIO_MOD,
-					    REQUEST_IIO_CMD2_OFFSET,
-					    REQUEST_IIO_CMD2_LEN, 0,
-					    REQUEST_IIO_CMD2_LEN, buf);
-	if (ret) {
-		pr_err("%s: Failed to get iio registers!", __func__);
+	ret = nct6694_read_msg(data->nct6694, REQUEST_IIO_MOD,
+			       REQUEST_IIO_CMD2_OFFSET,
+			       REQUEST_IIO_CMD2_LEN, 0,
+			       REQUEST_IIO_CMD2_LEN, buf);
+	if (ret)
 		goto err;
-	}
 
 	buf[IIO_SMI_CTRL_IDX] = 0x02;
-	ret = nct6694_setusb_wdata(data->nct6694, REQUEST_IIO_MOD,
-				   REQUEST_IIO_CMD2_OFFSET,
-				   REQUEST_IIO_CMD2_LEN, buf);
-	if (ret) {
-		pr_err("%s: Failed to set iio device!", __func__);
+	ret = nct6694_write_msg(data->nct6694, REQUEST_IIO_MOD,
+				REQUEST_IIO_CMD2_OFFSET,
+				REQUEST_IIO_CMD2_LEN, buf);
+	if (ret)
 		goto err;
-	}
 
 err:
 	mutex_unlock(&data->iio_lock);
@@ -571,7 +560,6 @@ static int nct6694_iio_probe(struct platform_device *pdev)
 	mutex_init(&data->iio_lock);
 	platform_set_drvdata(pdev, data);
 
-
 	ret = nct6694_iio_init(data);
 	if (ret)
 		return -EIO;
@@ -588,8 +576,6 @@ static int nct6694_iio_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "Failed to register iio device!\n");
 		return ret;
 	}
-
-	dev_info(&pdev->dev, "Probe device :%s", pdev->name);
 
 	return 0;
 }
@@ -613,7 +599,6 @@ static int __init nct6694_init(void)
 
 	err = platform_driver_register(&nct6694_iio_driver);
 	if (!err) {
-		pr_info(DRVNAME ": platform_driver_register\n");
 		if (err)
 			platform_driver_unregister(&nct6694_iio_driver);
 	}
@@ -631,4 +616,3 @@ module_exit(nct6694_exit);
 MODULE_DESCRIPTION("USB-iio driver for NCT6694");
 MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
 MODULE_LICENSE("GPL");
-

--- a/drivers/watchdog/nct6694_wdt.c
+++ b/drivers/watchdog/nct6694_wdt.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Nuvoton NCT6694 WDT driver based on USB interface.
  *
@@ -9,12 +9,12 @@
 #include <linux/slab.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/mfd/core.h>
 #include <linux/platform_device.h>
 #include <linux/mfd/nct6694.h>
 
 #define DRVNAME "nct6694-wdt"
 
-#define NR_WDT	2
 #define WATCHDOG_TIMEOUT	10
 #define WATCHDOG_PRETIMEOUT	0
 
@@ -24,10 +24,10 @@
 /* Message Channel*/
 /* Command 00h */
 #define REQUEST_WDT_CMD0_LEN	0x0F
-#define REQUEST_WDT_CMD0_OFFSET(idx) (idx ? 0x0100 : 0x0000)	/* OFFSET = SEL|CMD */
+#define REQUEST_WDT_CMD0_OFFSET(idx)	(idx ? 0x0100 : 0x0000)	/* OFFSET = SEL|CMD */
 #define WDT_PRETIMEOUT_IDX	0x00
 #define WDT_PRETIMEOUT_LEN	0x04	/* PRETIMEOUT(3byte) | ACT(1byte) */
-#define WDT_IMEOUT_IDX		0x04
+#define WDT_TIMEOUT_IDX		0x04
 #define WDT_TIMEOUT_LEN		0x04	/* TIMEOUT(3byte) | ACT(1byte) */
 #define WDT_COUNTDOWN_IDX	0x0C
 #define WDT_COUNTDOWN_LEN	0x03
@@ -35,19 +35,11 @@
 #define WDT_PRETIMEOUT_ACT	BIT(1)
 #define WDT_TIMEOUT_ACT		BIT(1)
 
-
 /* Command 01h */
-#define REQUEST_WDT_CMD1_LEN	0x04
-#define REQUEST_WDT_CMD1_OFFSET(idx) (idx ? 0x0101 : 0x0001)	/* OFFSET = SEL|CMD */
-#define WDT_CMD_IDX		0x00
-#define WDT_CMD_LEN		0x04
-
-#define SET_BUF32(buf, u32_val) { \
-	*(((u8 *)buf)+0) = u32_val & 0xFF; \
-	*(((u8 *)buf)+1) = (u32_val>>8) & 0xFF; \
-	*(((u8 *)buf)+2) = (u32_val>>16) & 0xFF; \
-	*(((u8 *)buf)+3) = (u32_val>>24) & 0xFF; \
-}
+#define REQUEST_WDT_CMD1_LEN		0x04
+#define REQUEST_WDT_CMD1_OFFSET(idx)	(idx ? 0x0101 : 0x0001)	/* OFFSET = SEL|CMD */
+#define WDT_CMD_IDX			0x00
+#define WDT_CMD_LEN			0x04
 
 static unsigned int timeout;
 module_param(timeout, int, 0);
@@ -62,40 +54,42 @@ module_param(nowayout, bool, 0);
 MODULE_PARM_DESC(nowayout, "Watchdog cannot be stopped once started (default="
 			   __MODULE_STRING(WATCHDOG_NOWAYOUT) ")");
 
-
 struct nct6694_wdt_data {
 	struct nct6694 *nct6694;
-	struct nct6694_wdt_dev *wdevs;
-	int nr_wdev;
-};
-
-struct nct6694_wdt_dev {
 	struct watchdog_device wdev;
-	struct nct6694_wdt_data *data;
 	unsigned int wdev_idx;
 };
 
+static inline void set_buf32(void *buf, u32 u32_val)
+{
+	u8 *p = (u8 *)buf;
+
+	p[0] = u32_val & 0xFF;
+	p[1] = (u32_val >> 8) & 0xFF;
+	p[2] = (u32_val >> 16) & 0xFF;
+	p[3] = (u32_val >> 24) & 0xFF;
+}
 
 static int nct6694_wdt_start(struct watchdog_device *wdev)
 {
-	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
+	struct nct6694_wdt_data *data = watchdog_get_drvdata(wdev);
 
-	pr_info("%s: WDT(%d) Start\n", __func__, wdt->wdev_idx);
+	pr_debug("%s: WDT(%d) Start\n", __func__, data->wdev_idx);
 
 	return 0;
 }
 
 static int nct6694_wdt_stop(struct watchdog_device *wdev)
 {
-	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
-	struct nct6694 *nct6694 = wdt->data->nct6694;
+	struct nct6694_wdt_data *data = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = data->nct6694;
 	unsigned char buf[REQUEST_WDT_CMD1_LEN] = {'W', 'D', 'T', 'C'};
 	int ret;
 
-	pr_info("%s: WDT(%d) Close\n", __func__, wdt->wdev_idx);
-	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
-				   REQUEST_WDT_CMD1_OFFSET(wdt->wdev_idx),
-				   REQUEST_WDT_CMD1_LEN, buf);
+	pr_debug("%s: WDT(%d) Close\n", __func__, data->wdev_idx);
+	ret = nct6694_write_msg(nct6694, REQUEST_WDT_MOD,
+				REQUEST_WDT_CMD1_OFFSET(data->wdev_idx),
+				REQUEST_WDT_CMD1_LEN, buf);
 	if (ret)
 		pr_err("%s: Failed to start WDT device!\n", __func__);
 
@@ -104,47 +98,50 @@ static int nct6694_wdt_stop(struct watchdog_device *wdev)
 
 static int nct6694_wdt_ping(struct watchdog_device *wdev)
 {
-	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
-	struct nct6694 *nct6694 = wdt->data->nct6694;
+	struct nct6694_wdt_data *data = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = data->nct6694;
 	unsigned char buf[REQUEST_WDT_CMD1_LEN] = {'W', 'D', 'T', 'S'};
 	int ret;
 
-	pr_debug("%s: WDT(%d) Ping\n", __func__, wdt->wdev_idx);
-	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
-				   REQUEST_WDT_CMD1_OFFSET(wdt->wdev_idx),
-				   REQUEST_WDT_CMD1_LEN, buf);
+	pr_debug("%s: WDT(%d) Ping\n", __func__, data->wdev_idx);
+	ret = nct6694_write_msg(nct6694, REQUEST_WDT_MOD,
+				REQUEST_WDT_CMD1_OFFSET(data->wdev_idx),
+				REQUEST_WDT_CMD1_LEN, buf);
 	if (ret)
-		pr_err("%s: Failed to Ping WDT device!\n", __func__);
+		pr_err("%s: Failed to ping WDT device!\n", __func__);
 
-	return 0;
+	return ret;
 }
 
 static int nct6694_wdt_set_timeout(struct watchdog_device *wdev,
 				   unsigned int timeout)
 {
-	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
-	struct nct6694 *nct6694 = wdt->data->nct6694;
+	struct nct6694_wdt_data *data = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = data->nct6694;
 	unsigned int timeout_fmt, pretimeout_fmt;
 	unsigned char buf[REQUEST_WDT_CMD0_LEN];
 	int ret;
 
 	if (timeout < wdev->pretimeout) {
-		pr_err("%s: 'timeout' must be greater than 'pre timeout'!", __func__);
+		pr_err("%s: 'timeout' must be greater than 'pre timeout'!\n",
+		       __func__);
 		return -EINVAL;
 	}
 
 	timeout_fmt = timeout * 1000 | (WDT_TIMEOUT_ACT << 24);
 	pretimeout_fmt = wdev->pretimeout * 1000 | (WDT_PRETIMEOUT_ACT << 24);
-	SET_BUF32(&buf[WDT_IMEOUT_IDX], le32_to_cpu(timeout_fmt));
-	SET_BUF32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
+	set_buf32(&buf[WDT_TIMEOUT_IDX], le32_to_cpu(timeout_fmt));
+	set_buf32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
 
-	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
-				   REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
-				   REQUEST_WDT_CMD0_LEN, buf);
+	ret = nct6694_write_msg(nct6694, REQUEST_WDT_MOD,
+				REQUEST_WDT_CMD0_OFFSET(data->wdev_idx),
+				REQUEST_WDT_CMD0_LEN, buf);
 	if (ret) {
-		pr_err("%s: Don't write the setup command in Start stage!\n", __func__);
+		pr_err("%s: Don't write the setup command in Start stage!\n",
+		       __func__);
 		return ret;
 	}
+
 	wdev->timeout = timeout;
 
 	return 0;
@@ -153,56 +150,58 @@ static int nct6694_wdt_set_timeout(struct watchdog_device *wdev,
 static int nct6694_wdt_set_pretimeout(struct watchdog_device *wdev,
 				      unsigned int pretimeout)
 {
-	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
-	struct nct6694 *nct6694 = wdt->data->nct6694;
+	struct nct6694_wdt_data *data = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = data->nct6694;
 	unsigned int timeout_fmt, pretimeout_fmt;
 	unsigned char buf[REQUEST_WDT_CMD0_LEN];
 	int ret;
 
 	if (pretimeout > wdev->timeout) {
-		pr_err("%s: 'pre timeout' must be less than 'timeout'!", __func__);
+		pr_err("%s: 'pre timeout' must be less than 'timeout'!\n",
+		       __func__);
 		return -EINVAL;
 	}
 	timeout_fmt = wdev->timeout * 1000 | (WDT_TIMEOUT_ACT << 24);
 	pretimeout_fmt = pretimeout * 1000 | (WDT_PRETIMEOUT_ACT << 24);
-	SET_BUF32(&buf[WDT_IMEOUT_IDX], le32_to_cpu(timeout_fmt));
-	SET_BUF32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
+	set_buf32(&buf[WDT_TIMEOUT_IDX], le32_to_cpu(timeout_fmt));
+	set_buf32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
 
-	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
-					    REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
-					    REQUEST_WDT_CMD0_LEN, buf);
+	ret = nct6694_write_msg(nct6694, REQUEST_WDT_MOD,
+				REQUEST_WDT_CMD0_OFFSET(data->wdev_idx),
+				REQUEST_WDT_CMD0_LEN, buf);
 	if (ret) {
-		pr_info("%s: Don't write the setup command in Start stage!\n", __func__);
+		pr_err("%s: Don't write the setup command in Start stage!\n", __func__);
 		return ret;
 	}
+
 	wdev->pretimeout = pretimeout;
 	return 0;
 }
 
 static unsigned int nct6694_wdt_get_time(struct watchdog_device *wdev)
 {
-	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
-	struct nct6694 *nct6694 = wdt->data->nct6694;
+	struct nct6694_wdt_data *data = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = data->nct6694;
 	unsigned char buf[WDT_COUNTDOWN_LEN];
 	unsigned int timeleft_ms;
 	int ret;
 
-	ret = nct6694_getusb(nct6694, REQUEST_WDT_MOD,
-				      REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
-				      REQUEST_WDT_CMD0_LEN, WDT_COUNTDOWN_IDX,
-				      WDT_COUNTDOWN_LEN, buf);
+	ret = nct6694_read_msg(nct6694, REQUEST_WDT_MOD,
+			       REQUEST_WDT_CMD0_OFFSET(data->wdev_idx),
+			       REQUEST_WDT_CMD0_LEN, WDT_COUNTDOWN_IDX,
+			       WDT_COUNTDOWN_LEN, buf);
 	if (ret)
-		pr_info("%s: Failed to get WDT device!\n", __func__);
+		pr_err("%s: Failed to get WDT device!\n", __func__);
 
 	timeleft_ms = ((buf[2] << 16) | (buf[1] << 8) | buf[0]) & 0xFFFFFF;
 
-	return timeleft_ms/1000;
+	return timeleft_ms / 1000;
 }
 
 static int nct6694_wdt_setup(struct watchdog_device *wdev)
 {
-	struct nct6694_wdt_dev *wdt = watchdog_get_drvdata(wdev);
-	struct nct6694 *nct6694 = wdt->data->nct6694;
+	struct nct6694_wdt_data *data = watchdog_get_drvdata(wdev);
+	struct nct6694 *nct6694 = data->nct6694;
 	unsigned char buf[REQUEST_WDT_CMD0_LEN] = {0};
 	unsigned int timeout_fmt, pretimeout_fmt;
 	int ret;
@@ -212,33 +211,32 @@ static int nct6694_wdt_setup(struct watchdog_device *wdev)
 
 	if (pretimeout) {
 		wdev->pretimeout = pretimeout;
-		pretimeout_fmt = wdev->pretimeout*1000 | (WDT_PRETIMEOUT_ACT << 24);
+		pretimeout_fmt = wdev->pretimeout * 1000 | (WDT_PRETIMEOUT_ACT << 24);
 	} else {
 		pretimeout_fmt = 0;
 	}
 
-	timeout_fmt = wdev->timeout*1000 | (WDT_TIMEOUT_ACT << 24);
-	SET_BUF32(&buf[WDT_IMEOUT_IDX], le32_to_cpu(timeout_fmt));
-	SET_BUF32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
+	timeout_fmt = wdev->timeout * 1000 | (WDT_TIMEOUT_ACT << 24);
+	set_buf32(&buf[WDT_TIMEOUT_IDX], le32_to_cpu(timeout_fmt));
+	set_buf32(&buf[WDT_PRETIMEOUT_IDX], le32_to_cpu(pretimeout_fmt));
 
-	ret = nct6694_setusb_wdata(nct6694, REQUEST_WDT_MOD,
-					    REQUEST_WDT_CMD0_OFFSET(wdt->wdev_idx),
-					    REQUEST_WDT_CMD0_LEN, buf);
+	ret = nct6694_write_msg(nct6694, REQUEST_WDT_MOD,
+				REQUEST_WDT_CMD0_OFFSET(data->wdev_idx),
+				REQUEST_WDT_CMD0_LEN, buf);
 	if (ret)
 		return ret;
 
-	pr_info("Setting WDT(%d): timeout = %d, pretimeout = %d", wdt->wdev_idx,
-								  wdev->timeout,
-								  wdev->pretimeout);
+	pr_info("Setting WDT(%d): timeout = %d, pretimeout = %d\n",
+		data->wdev_idx, wdev->timeout, wdev->pretimeout);
 
 	return 0;
 }
 
 static const struct watchdog_info nct6694_wdt_info = {
-	.options = WDIOF_SETTIMEOUT		|
-			   WDIOF_KEEPALIVEPING	|
-				WDIOF_MAGICCLOSE	|
-				WDIOF_PRETIMEOUT,
+	.options = WDIOF_SETTIMEOUT	|
+		   WDIOF_KEEPALIVEPING	|
+		   WDIOF_MAGICCLOSE	|
+		   WDIOF_PRETIMEOUT,
 	.identity = DRVNAME,
 };
 
@@ -246,70 +244,55 @@ static const struct watchdog_ops nct6694_wdt_ops = {
 	.owner = THIS_MODULE,
 	.start = nct6694_wdt_start,
 	.stop = nct6694_wdt_stop,
-	.ping = nct6694_wdt_ping,
 	.set_timeout = nct6694_wdt_set_timeout,
 	.set_pretimeout = nct6694_wdt_set_pretimeout,
 	.get_timeleft = nct6694_wdt_get_time,
+	.ping = nct6694_wdt_ping,
 };
-
-#define NCT6694_WDT_DEVICE(_wdev_idx)	\
-{	\
-	.wdev = {	\
-		.info	= &nct6694_wdt_info,	\
-		.ops  = &nct6694_wdt_ops,	\
-		.timeout = WATCHDOG_TIMEOUT,	\
-		.pretimeout = WATCHDOG_PRETIMEOUT,	\
-		.min_timeout = 1,	\
-		.max_timeout = 255,	\
-	},	\
-	.wdev_idx = _wdev_idx,	\
-}
-
-static struct nct6694_wdt_dev nct6694_wdt_dev[] = {
-	NCT6694_WDT_DEVICE(0),
-	NCT6694_WDT_DEVICE(1),
-};
-
 
 static int nct6694_wdt_probe(struct platform_device *pdev)
 {
-	struct nct6694_wdt_data *data;
+	const struct mfd_cell *cell = mfd_get_cell(pdev);
 	struct nct6694 *nct6694 = dev_get_drvdata(pdev->dev.parent);
-	int i, ret;
+	struct nct6694_wdt_data *data;
+	struct watchdog_device *wdev;
+	int ret;
 
-	data = kzalloc(sizeof(*data), GFP_KERNEL);
+	data = devm_kzalloc(&pdev->dev, sizeof(*data), GFP_KERNEL);
 	if (!data)
 		return -ENOMEM;
 
 	data->nct6694 = nct6694;
-	data->wdevs = nct6694_wdt_dev;
-	data->nr_wdev = ARRAY_SIZE(nct6694_wdt_dev);
+	data->wdev_idx = cell->id;
+
+	wdev = &data->wdev;
+	wdev->info = &nct6694_wdt_info;
+	wdev->ops = &nct6694_wdt_ops;
+	wdev->timeout = WATCHDOG_TIMEOUT;
+	wdev->pretimeout = WATCHDOG_PRETIMEOUT;
+	wdev->min_timeout = 1;
+	wdev->max_timeout = 255;
+
 	platform_set_drvdata(pdev, data);
 
-	/* Register each wdt device to WDT framework */
-	for (i = 0; i < data->nr_wdev; i++) {
-		struct nct6694_wdt_dev *wdev = &data->wdevs[i];
+	/* Register watchdog timer device to WDT framework */
+	watchdog_set_drvdata(&data->wdev, data);
+	watchdog_init_timeout(&data->wdev, timeout, &pdev->dev);
+	watchdog_set_nowayout(&data->wdev, nowayout);
+	watchdog_stop_on_reboot(&data->wdev);
 
-		wdev->data = data;
-		watchdog_set_drvdata(&data->wdevs[i].wdev, &data->wdevs[i]);
-		watchdog_init_timeout(&data->wdevs[i].wdev, timeout, &pdev->dev);
-		watchdog_set_nowayout(&data->wdevs[i].wdev, nowayout);
-		watchdog_stop_on_reboot(&data->wdevs[i].wdev);
-
-		ret = watchdog_register_device(&data->wdevs[i].wdev);
-		if (ret) {
-			dev_err(&pdev->dev, "Failed to register watchdog device: %d", ret);
-			return ret;
-		}
-
-		ret = nct6694_wdt_setup(&data->wdevs[i].wdev);
-		if (ret) {
-			dev_err(&pdev->dev, "Failed to setup WDT device!");
-			return ret;
-		}
+	ret = devm_watchdog_register_device(&pdev->dev, &data->wdev);
+	if (ret) {
+		dev_err(&pdev->dev, "%s: Failed to register watchdog device: %d\n",
+			__func__, ret);
+		return ret;
 	}
 
-	dev_info(&pdev->dev, "Probe device :%s", pdev->name);
+	ret = nct6694_wdt_setup(&data->wdev);
+	if (ret) {
+		dev_err(&pdev->dev, "Failed to setup WDT device!\n");
+		return ret;
+	}
 
 	return 0;
 }
@@ -317,10 +300,6 @@ static int nct6694_wdt_probe(struct platform_device *pdev)
 static int nct6694_wdt_remove(struct platform_device *pdev)
 {
 	struct nct6694_wdt_data *data = platform_get_drvdata(pdev);
-	int i;
-
-	for (i = 0; i < data->nr_wdev; i++)
-		watchdog_unregister_device(&data->wdevs[i].wdev);
 
 	kfree(data);
 	return 0;
@@ -340,7 +319,6 @@ static int __init nct6694_init(void)
 
 	err = platform_driver_register(&nct6694_wdt_driver);
 	if (!err) {
-		pr_info(DRVNAME ": platform_driver_register\n");
 		if (err)
 			platform_driver_unregister(&nct6694_wdt_driver);
 	}
@@ -358,4 +336,3 @@ module_exit(nct6694_exit);
 MODULE_DESCRIPTION("USB-wdt driver for NCT6694");
 MODULE_AUTHOR("Tzu-Ming Yu <tmyu0@nuvoton.com>");
 MODULE_LICENSE("GPL");
-


### PR DESCRIPTION
Update drivers to meet the requirement that dynamically generated devices can match the same driver.